### PR TITLE
Added argument to create() to allow for client options

### DIFF
--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -36,14 +36,17 @@ class Crawler
     protected $crawlProfile;
 
     /**
+     * @param array $clientOptions
      * @return static
      */
-    public static function create()
+    public static function create(array $clientOptions = array())
     {
-        $client = new Client([
+        $options = array_merge([
             RequestOptions::ALLOW_REDIRECTS => false,
             RequestOptions::COOKIES         => true,
-        ]);
+        ], $clientOptions);
+
+        $client = new Client($options);
 
         return new static($client);
     }


### PR DESCRIPTION
For my project I needed the crawler to follow redirects. 

With this change I can initialise the crawler as follows

`Crawler::create([RequestOptions::ALLOW_REDIRECTS => true])
      ->setCrawlObserver($kriechenCrawler)
      ->setCrawlProfile($kriechenCrawler)
      ->startCrawling($url);
`
