### PR TITLE
Add logic to track DOM/HTML elements...

### DIFF
--- a/src/CrawlObserver.php
+++ b/src/CrawlObserver.php
@@ -7,22 +7,21 @@ interface CrawlObserver
     /**
      * Called when the crawler will crawl the url.
      *
-     * @param \Spatie\Crawler\Url $url
+     * @param \Spatie\Crawler\CrawlUrl $url
      *
      * @return void
      */
-    public function willCrawl(Url $url);
+    public function willCrawl(CrawlUrl $url);
 
     /**
      * Called when the crawler has crawled the given url.
      *
-     * @param \Spatie\Crawler\Url $url
+     * @param \Spatie\Crawler\CrawlUrl $url
      * @param \Psr\Http\Message\ResponseInterface|null $response
-     * @param \Spatie\Crawler\Url $foundOnUrl
      *
      * @return void
      */
-    public function hasBeenCrawled(Url $url, $response, Url $foundOnUrl = null);
+    public function hasBeenCrawled(CrawlUrl $url, $response);
 
     /**
      * Called when the crawl has ended.

--- a/src/CrawlUrl.php
+++ b/src/CrawlUrl.php
@@ -10,6 +10,9 @@ class CrawlUrl
     /** @var \Spatie\Crawler\Url */
     public $foundOnUrl;
 
+    /** @var \Spatie\Crawler\HtmlNode */
+    public $node;
+
     public static function create(Url $url, Url $foundOnUrl = null)
     {
         return new static($url, $foundOnUrl);
@@ -18,6 +21,7 @@ class CrawlUrl
     protected function __construct(Url $url, Url $foundOnUrl = null)
     {
         $this->url = $url;
+        $this->node = &$url->node;
 
         $this->foundOnUrl = $foundOnUrl;
     }

--- a/src/HtmlNode.php
+++ b/src/HtmlNode.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Spatie\Crawler;
+
+use DOMElement;
+use DOMDocument;
+
+class HtmlNode
+{
+
+    /** @var \DOMElement */
+    protected $node;
+
+    /**
+     * @param \DOMElement $node
+     *
+     * @return static
+     */
+    public static function create(DOMElement $node)
+    {
+        return new static($node);
+    }
+
+    public function __construct(DOMElement $node)
+    {
+      $this->node = $node;
+    }
+
+    /**
+     * @param void
+     *
+     * @return \DOMElement
+     */
+    public function getNode(): DOMElement
+    {
+      return $this->node;
+    }
+
+    /**
+     * @param void
+     *
+     * @return string
+     */
+    public function getHtml(): string
+    {
+        return $this->node->ownerDocument->saveHTML($this->node);
+    }
+
+    /**
+     * @param void
+     *
+     * @return string
+     */
+    public function getHtmlAndUpdateHref(string $href): string
+    {
+        return $this->node->setAttribute('href', $href)->ownerDocument->saveHTML($this->node);
+    }
+
+}

--- a/src/HtmlNode.php
+++ b/src/HtmlNode.php
@@ -3,7 +3,6 @@
 namespace Spatie\Crawler;
 
 use DOMElement;
-use DOMDocument;
 
 class HtmlNode
 {
@@ -23,7 +22,7 @@ class HtmlNode
 
     public function __construct(DOMElement $node)
     {
-      $this->node = $node;
+        $this->node = $node;
     }
 
     /**
@@ -33,7 +32,7 @@ class HtmlNode
      */
     public function getNode(): DOMElement
     {
-      return $this->node;
+        return $this->node;
     }
 
     /**

--- a/src/HtmlNode.php
+++ b/src/HtmlNode.php
@@ -6,7 +6,6 @@ use DOMElement;
 
 class HtmlNode
 {
-
     /** @var \DOMElement */
     protected $node;
 
@@ -54,5 +53,4 @@ class HtmlNode
     {
         return $this->node->setAttribute('href', $href)->ownerDocument->saveHTML($this->node);
     }
-
 }

--- a/src/Url.php
+++ b/src/Url.php
@@ -44,7 +44,7 @@ class Url
 
     public function __construct($node, $url = null)
     {
-        if (!is_null($node)) {
+        if (! is_null($node)) {
             $url = $node->getNode()->getAttribute('href');
         } else {
             $url = $url;
@@ -56,7 +56,7 @@ class Url
                 $this->$property = $urlProperties[$property];
             }
         }
-        $this->node = (!is_null($node)) ? $node : null;
+        $this->node = (! is_null($node)) ? $node : null;
     }
 
     public function isRelative(): bool

--- a/src/Url.php
+++ b/src/Url.php
@@ -19,18 +19,36 @@ class Url
     /** @var null|string */
     public $query;
 
+    /** @var \Spatie\Crawler\HtmlNode */
+    public $node;
+
+    /**
+     * @param HtmlNode $node
+     *
+     * @return static
+     */
+    public static function create(HtmlNode $node)
+    {
+        return new static($node, null);
+    }
+
     /**
      * @param string $url
      *
      * @return static
      */
-    public static function create(string $url)
+    public static function createFromString(string $url)
     {
-        return new static($url);
+        return new static(null, $url);
     }
 
-    public function __construct(string $url)
+    public function __construct($node, $url = null)
     {
+        if (!is_null($node)) {
+            $url = $node->getNode()->getAttribute('href');
+        } else {
+            $url = $url;
+        }
         $urlProperties = parse_url($url);
 
         foreach (['scheme', 'host', 'path', 'port', 'query'] as $property) {
@@ -38,6 +56,7 @@ class Url
                 $this->$property = $urlProperties[$property];
             }
         }
+        $this->node = (!is_null($node)) ? $node : null;
     }
 
     public function isRelative(): bool


### PR DESCRIPTION
...this is super useful for tracking link redirects that could be affecting SEO.

In particular this can be useful when it comes to generating a report, or even a "patch" file, of the redirecting links.

For example you crawl a website and are looking for onsite redirects, the same (or very similar) links are on multiple pages. Once the report is done it's much easier to address the various links and pages if you have context about what page the links on and where it is. By tracking the actual link tag this is much easier; additionally a 'corrected' link can also be presented in the report.

Example of the output:

```
SEO Warning: Redirect found on page: https://grandmascookieblog.com/
This HTML link:

<a href="/cloud.php">Onsite test</a>

redirects to: https://www.liquidweb.com/cloudsites/
The final page/URL is: https://www.liquidweb.com/cloudsites/. The corrected link is:

<a href="https://www.liquidweb.com/cloudsites/">Onsite test</a>
```