### PR TITLE
Patch path-relative URL crawling

### DIFF
--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -191,8 +191,8 @@ class Crawler
             ->filter(function (Url $url) {
                 return $url->hasCrawlableScheme();
             })
-            ->map(function (Url $url) {
-                return $this->normalizeUrl($url);
+            ->map(function (Url $url) use ($foundOnUrl) {
+                return $this->normalizeUrl($url, $foundOnUrl);
             })
             ->filter(function (Url $url) {
                 return $this->crawlProfile->shouldCrawl($url);
@@ -219,11 +219,17 @@ class Crawler
 
     /**
      * @param \Spatie\Crawler\Url $url
+     * @param \Spatie\Crawler\Url $foundOnUrl
      *
      * @return \Spatie\Crawler\Url
      */
-    protected function normalizeUrl(Url $url): Url
+    protected function normalizeUrl(Url $url, Url $foundOnUrl): Url
     {
+        if ($url->isRelativeToPath()) {
+            $directory = $foundOnUrl->directory();
+            $url->setPath($directory.$url->path());
+        }
+
         if ($url->isRelative()) {
             $url->setScheme($this->baseUrl->scheme)
                 ->setHost($this->baseUrl->host)

--- a/src/Url.php
+++ b/src/Url.php
@@ -45,6 +45,13 @@ class Url
         return is_null($this->host);
     }
 
+    public function isRelativeToPath(): bool
+    {
+        $doesntStartWithForwardSlash = substr($this->path(), 0, 1) != '/';
+
+        return $this->isRelative() && $doesntStartWithForwardSlash;
+    }
+
     public function isProtocolIndependent(): bool
     {
         return is_null($this->scheme);
@@ -102,11 +109,33 @@ class Url
     }
 
     /**
+     * @param $path
+     *
+     * @return $this
+     */
+    public function setPath(string $path)
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    /**
      * @return null|string
      */
     public function path()
     {
         return $this->path;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function directory()
+    {
+        $segments = $this->segments();
+        array_pop($segments);
+        return implode('/', $segments).'/';
     }
 
     /**

--- a/src/Url.php
+++ b/src/Url.php
@@ -135,6 +135,7 @@ class Url
     {
         $segments = $this->segments();
         array_pop($segments);
+
         return implode('/', $segments).'/';
     }
 

--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -37,6 +37,9 @@ class CrawlerTest extends TestCase
             ['url' => 'http://localhost:8080/link3', 'foundOn' => 'http://localhost:8080/link2'],
             ['url' => 'http://localhost:8080/notExists', 'foundOn' => 'http://localhost:8080/link3'],
             ['url' => 'http://example.com/', 'foundOn' => 'http://localhost:8080/link1'],
+            ['url' => 'http://localhost:8080/dir/link4', 'foundOn' => 'http://localhost:8080/'],
+            ['url' => 'http://localhost:8080/dir/link5', 'foundOn' => 'http://localhost:8080/dir/link4'],
+            ['url' => 'http://localhost:8080/dir/subdir/link6', 'foundOn' => 'http://localhost:8080/dir/link5'],
         ]);
     }
 

--- a/tests/server/server.js
+++ b/tests/server/server.js
@@ -3,7 +3,7 @@
 let app = require('express')();
 
 app.get('/', function (request, response) {
-    response.end('<a href="/link1">Link1</a><a href="/link2">Link2</a><a href="mailto:test@example.com">Email</a>');
+    response.end('<a href="/link1">Link1</a><a href="/link2">Link2</a><a href="dir/link4">Link4</a><a href="mailto:test@example.com">Email</a>');
 });
 
 app.get('/link1', function (request, response) {
@@ -16,6 +16,18 @@ app.get('/link2', function (request, response) {
 
 app.get('/link3', function (request, response) {
     response.end('You are on link3<a href="/notExists">not exists</a>');
+});
+
+app.get('/dir/link4', function (request, response) {
+    response.end('You are on /dir/link4<a href="link5">link 5</a>');
+});
+
+app.get('/dir/link5', function (request, response) {
+    response.end('You are on /dir/link5<a href="subdir/link6">link 6</a>');
+});
+
+app.get('/dir/subdir/link6', function (request, response) {
+    response.end('You are on /dir/subdir/link6<a href="/link1">link 1</a>');
 });
 
 let server = app.listen(8080, function () {


### PR DESCRIPTION
Check whether urls on the crawled page are path-relative urls. If so; add the directory of the current path before their path-relative path.

For example crawling this page:

```html
<!-- http://example.com/directory/subdirectory/index.html -->

<a href="example.html">example</a>
```

will add `http://example.com/directory/subdirectory/example.html` to the crawl queue instead of `http://example.com/example.html`.

Fixes #52 