### PR TITLE
Fix setting maximum response size

### DIFF
--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -3,12 +3,12 @@
 namespace Spatie\Crawler\Test;
 
 use GuzzleHttp\Psr7\Uri;
-use Spatie\Crawler\Crawler;
-use Spatie\Crawler\CrawlProfile;
 use Psr\Http\Message\UriInterface;
 use Spatie\Browsershot\Browsershot;
-use Spatie\Crawler\CrawlSubdomains;
+use Spatie\Crawler\Crawler;
 use Spatie\Crawler\CrawlInternalUrls;
+use Spatie\Crawler\CrawlProfile;
+use Spatie\Crawler\CrawlSubdomains;
 use Spatie\Crawler\EmptyCrawlObserver;
 
 class CrawlerTest extends TestCase
@@ -167,6 +167,25 @@ class CrawlerTest extends TestCase
 
             $this->assertCrawledUrlCount($maximumCrawlCount);
         }
+    }
+
+    /** @test */
+    public function it_doesnt_extract_links_if_the_crawled_page_exceeds_the_maximum_response_size()
+    {
+        Crawler::create()
+            ->setCrawlObserver(new CrawlLogger())
+            ->setMaximumResponseSize(10)
+            ->startCrawling('http://localhost:8080');
+
+        $this->assertCrawledOnce([
+            ['url' => 'http://localhost:8080/'],
+        ]);
+
+        $this->assertNotCrawled([
+            ['url' => 'http://localhost:8080/link1', 'foundOn' => 'http://localhost:8080/'],
+            ['url' => 'http://localhost:8080/link2', 'foundOn' => 'http://localhost:8080/'],
+            ['url' => 'http://localhost:8080/dir/link4', 'foundOn' => 'http://localhost:8080/'],
+        ]);
     }
 
     /** @test */


### PR DESCRIPTION
When a crawled response exceeds the set maximum response size (±2MB by default) it will not be parsed for new URLs to crawl. 

Users parsing the `$response->getBody()` in `CrawlObserver::hasBeenCrawled()` should still be cautious as `setMaximumResponseSize` doesn't stop the responses from being passed to `hasBeenCrawled()`