### PR TITLE
fix to mark url's that should not be crawled as processed

### DIFF
--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -314,7 +314,8 @@ class Crawler
     protected function getCrawlRequests(): Generator
     {
         while ($crawlUrl = $this->crawlQueue->getFirstPendingUrl()) {
-            if (! $this->crawlProfile->shouldCrawl($crawlUrl->url)) {
+            if ( ! $this->crawlProfile->shouldCrawl($crawlUrl->url)) {
+                $this->crawlQueue->markAsProcessed($crawlUrl);
                 continue;
             }
 

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -314,7 +314,7 @@ class Crawler
     protected function getCrawlRequests(): Generator
     {
         while ($crawlUrl = $this->crawlQueue->getFirstPendingUrl()) {
-            if ( ! $this->crawlProfile->shouldCrawl($crawlUrl->url)) {
+            if (! $this->crawlProfile->shouldCrawl($crawlUrl->url)) {
                 $this->crawlQueue->markAsProcessed($crawlUrl);
                 continue;
             }


### PR DESCRIPTION
In my use case the while loop goes into an endless loop, when marked as processed this is no longer an issue.