### PR TITLE
Removed php native type hinting of url, queue and crawler pool Closures

### DIFF
--- a/src/CrawlQueue/CollectionCrawlQueue.php
+++ b/src/CrawlQueue/CollectionCrawlQueue.php
@@ -40,11 +40,11 @@ class CollectionCrawlQueue implements CrawlQueue
     }
 
     /**
-     * @param int $id
+     * @param mixed $id
      *
      * @return \Spatie\Crawler\CrawlUrl|null
      */
-    public function getUrlById(int $id): CrawlUrl
+    public function getUrlById($id): CrawlUrl
     {
         if (! isset($this->urls->values()[$id])) {
             throw new UrlNotFoundByIndex("#{$id} crawl url not found in collection");

--- a/src/CrawlQueue/CrawlQueue.php
+++ b/src/CrawlQueue/CrawlQueue.php
@@ -12,7 +12,7 @@ interface CrawlQueue
 
     public function hasPendingUrls(): bool;
 
-    public function getUrlById(int $id): CrawlUrl;
+    public function getUrlById($id): CrawlUrl;
 
     /** @return \Spatie\Crawler\CrawlUrl|null */
     public function getFirstPendingUrl();

--- a/src/CrawlUrl.php
+++ b/src/CrawlUrl.php
@@ -12,10 +12,10 @@ class CrawlUrl
     /** @var \Psr\Http\Message\UriInterface */
     public $foundOnUrl;
 
-    /** @var int */
+    /** @var mixed */
     protected $id;
 
-    public static function create(UriInterface $url, ?UriInterface $foundOnUrl = null, int $id = null)
+    public static function create(UriInterface $url, ?UriInterface $foundOnUrl = null, $id = null)
     {
         $static = new static($url, $foundOnUrl);
 
@@ -32,12 +32,15 @@ class CrawlUrl
         $this->foundOnUrl = $foundOnUrl;
     }
 
-    public function getId(): int
+    /**
+     * @return mixed|null
+     */
+    public function getId()
     {
         return $this->id;
     }
 
-    public function setId(int $id)
+    public function setId($id)
     {
         $this->id = $id;
     }

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -255,7 +255,7 @@ class Crawler
             $pool = new Pool($this->client, $this->getCrawlRequests(), [
                 'concurrency' => $this->concurrency,
                 'options' => $this->client->getConfig(),
-                'fulfilled' => function (ResponseInterface $response, int $index) {
+                'fulfilled' => function (ResponseInterface $response, $index) {
                     $crawlUrl = $this->crawlQueue->getUrlById($index);
                     $this->handleCrawled($response, $crawlUrl);
 
@@ -272,7 +272,7 @@ class Crawler
                         $crawlUrl->url
                     );
                 },
-                'rejected' => function (RequestException $exception, int $index) {
+                'rejected' => function (RequestException $exception, $index) {
                     $this->handleCrawlFailed(
                         $exception,
                         $this->crawlQueue->getUrlById($index),


### PR DESCRIPTION
In order to support any kind of url indexing, int type hinting should be removed. Also, added phpdoc comments where needed.