### PR TITLE
Added meta robots follow/nofollow directive check and ignoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,14 @@ Crawler::create()
     ->setCrawlQueue(<implementation of \Spatie\Crawler\CrawlQueue\CrawlQueue>)
 ```
 
+## Honoring robots meta tag
+
+By default the crawler will honor follow/nofollow directive. You can change it with `doNotHonorMetaRobotsFollowPolicy` method or re-enable it with `honorMetaRobotsFollowPolicy`.
+```php
+Crawler::create()
+    ->doNotHonorMetaRobotsFollowPolicy()
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -353,6 +353,17 @@ class CrawlerTest extends TestCase
         $this->assertNotCrawled([['url' => 'http://localhost:8080/nofollow', 'foundOn' => 'http://localhost:8080/']]);
     }
 
+    /** @test */
+    public function it_should_not_follow_links_from_nofollow_pages()
+    {
+        Crawler::create()
+            ->setCrawlObserver(new CrawlLogger())
+            ->setMaximumDepth(2)
+            ->startCrawling('http://localhost:8080');
+
+        $this->assertNotCrawled([['url' => 'http://localhost:8080/unreachable', 'foundOn' => 'http://localhost:8080/nofollowpage']]);
+    }
+
     protected function regularUrls(): array
     {
         return [

--- a/tests/server/server.js
+++ b/tests/server/server.js
@@ -3,7 +3,7 @@
 let app = require('express')();
 
 app.get('/', function (request, response) {
-    response.end('<a href="/link1">Link1</a><a href="/link2">Link2</a><a href="dir/link4">Link4</a><a href="mailto:test@example.com">Email</a><a href="tel:123">Telephone</a><a href="/nofollow" rel="nofollow">No follow</a>');
+    response.end('<a href="/link1">Link1</a><a href="/link2">Link2</a><a href="dir/link4">Link4</a><a href="mailto:test@example.com">Email</a><a href="tel:123">Telephone</a><a href="/nofollow" rel="nofollow">No follow</a><a href="/nofollowpage">No follow Page</a>');
 });
 
 app.get('/link1', function (request, response) {
@@ -16,6 +16,12 @@ app.get('/javascript', function (request, response) {
 
 app.get('/nofollow', function (request, response) {
     response.end('This page should not be crawled');
+});
+app.get('/nofollowpage', function (reques, response) {
+    response.end('<html><head><meta name="robots" content="noindex,nofollow"></head><a href="/unreachable">unreachable</a></html>');
+});
+app.get('/unreachable', function (reques, response) {
+    response.end('This page should be unreachable from a robots nofollow page.');
 });
 
 app.get('/link2', function (request, response) {


### PR DESCRIPTION
This change allows to honor robots meta tag nofollow directive. It can be enabled and disabled with to methods. Its is checked in every page after loading JS.