### PR TITLE
Allow the crawler to run without any observers

### DIFF
--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -32,7 +32,7 @@ class Crawler
     protected $baseUrl;
 
     /** @var array[\Spatie\Crawler\CrawlObserver] */
-    protected $crawlObservers;
+    protected $crawlObservers = [];
 
     /** @var \Spatie\Crawler\CrawlProfile */
     protected $crawlProfile;


### PR DESCRIPTION
Useful for features like https://github.com/spatie/laravel-responsecache/issues/133

What do you think @freekmurze?