### PR TITLE
Changed access method for $defaultClientOptions

### DIFF
--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -86,7 +86,7 @@ class Crawler
     {
         $clientOptions = (count($clientOptions))
             ? $clientOptions
-            : self::$defaultClientOptions;
+            : static::$defaultClientOptions;
 
         $client = new Client($clientOptions);
 


### PR DESCRIPTION
Changed from self to static for overwriting $defaultClientOptions in a derived class