### PR TITLE
Corrected not marking processed links on a falsy shouldCrawl return

### DIFF
--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -407,6 +407,8 @@ class Crawler
                 continue;
             }
 
+	$this->crawlQueue->markAsProcessed($crawlUrl);
+
             if ($this->crawlQueue->hasAlreadyBeenProcessed($crawlUrl)) {
                 continue;
             }
@@ -414,8 +416,6 @@ class Crawler
             foreach ($this->crawlObservers as $crawlObserver) {
                 $crawlObserver->willCrawl($crawlUrl->url);
             }
-
-            $this->crawlQueue->markAsProcessed($crawlUrl);
 
             yield $crawlUrl->getId() => new Request('GET', $crawlUrl->url);
         }


### PR DESCRIPTION
I had an issue with creating CrawlProfiles and even using those povided:

Problem was when the shouldCrawl function returned false, the crawling loop skipped the markProcessed method call, so the link would be checked again, which causes php to exceed maximum runtime.

It is working fine on my project now.