### PR TITLE
Moves the number of urls counted to the Queue

### DIFF
--- a/src/CrawlQueue/CollectionCrawlQueue.php
+++ b/src/CrawlQueue/CollectionCrawlQueue.php
@@ -90,6 +90,11 @@ class CollectionCrawlQueue implements CrawlQueue
         return $this->pendingUrls->first();
     }
 
+    public function count(): int
+    {
+        return $this->urls->count();
+    }
+
     /**
      * @param \Illuminate\Support\Collection|\Tightenco\Collect\Support\Collection $collection
      * @param \Spatie\Crawler\CrawlUrl                                             $searchCrawlUrl

--- a/src/CrawlQueue/CrawlQueue.php
+++ b/src/CrawlQueue/CrawlQueue.php
@@ -20,4 +20,6 @@ interface CrawlQueue
     public function hasAlreadyBeenProcessed(CrawlUrl $url): bool;
 
     public function markAsProcessed(CrawlUrl $crawlUrl);
+
+    public function count(): int;
 }

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -38,9 +38,6 @@ class Crawler
     /** @var \Spatie\Crawler\CrawlQueue\CrawlQueue */
     protected $crawlQueue;
 
-    /** @var int */
-    protected $crawledUrlCount = 0;
-
     /** @var int|null */
     protected $maximumCrawlCount = null;
 
@@ -140,7 +137,7 @@ class Crawler
 
     public function getCrawlerUrlCount(): int
     {
-        return $this->crawledUrlCount;
+        return $this->crawlQueue->count();
     }
 
     public function setMaximumDepth(int $maximumDepth): Crawler
@@ -430,8 +427,6 @@ class Crawler
         if ($this->getCrawlQueue()->has($crawlUrl->url)) {
             return $this;
         }
-
-        $this->crawledUrlCount++;
 
         $this->crawlQueue->add($crawlUrl);
 

--- a/tests/CrawlQueueTest.php
+++ b/tests/CrawlQueueTest.php
@@ -28,6 +28,28 @@ class CrawlQueueTest extends TestCase
     }
 
     /** @test */
+    public function it_can_give_a_count_of_the_urls_stored()
+    {
+        $this->assertEquals(0, $this->crawlQueue->count());
+
+        $crawlUrl = $this->createCrawlUrl('https://example.com');
+        $this->crawlQueue->add($crawlUrl);
+
+        $this->assertEquals(1, $this->crawlQueue->count());
+
+        $crawlUrl = $this->createCrawlUrl('https://example1.com');
+        $this->crawlQueue->add($crawlUrl);
+
+        $this->assertEquals(2, $this->crawlQueue->count());
+
+        // Checks it doesn't count duplicates
+        $crawlUrl = $this->createCrawlUrl('https://example1.com');
+        $this->crawlQueue->add($crawlUrl);
+
+        $this->assertEquals(2, $this->crawlQueue->count());
+    }
+
+    /** @test */
     public function it_can_determine_if_there_are_pending_urls()
     {
         $this->assertFalse($this->crawlQueue->hasPendingUrls());


### PR DESCRIPTION
I've been playing around with the Crawler package lately but noticed the number of URLs processed tallied up in the crawler instance and it seems to me that it would make more sense being in the Queue applied to the crawler that stores all the urls that have been added. This isn't a breaking change other than for those who have their own Queue implementations but it should be a minor change to add a count.

The advantage of this is it means that a shared Queue between crawlers will stop when the queue has globally reached any count set between all of them instead of when that individual crawler reached the maximum crawl count. I could imagine there being scenarios where someone wants either though and I don't mind putting in the work if that is considered a more useful approach?