### PR TITLE
Randomized Proxy Support

### DIFF
--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -335,6 +335,14 @@ class Crawler
         return $this->baseUrl;
     }
 
+    public function setProxies(array $proxyConfig)
+    {
+        $this->proxyConfig = $proxyConfig;
+        $this->usingProxies = true;
+        
+        return $this;
+    }
+
     /**
      * @param \Psr\Http\Message\UriInterface|string $baseUrl
      */
@@ -416,14 +424,6 @@ class Crawler
 
             $promise->wait();
         }
-    }
-
-    public function setProxies(array $proxyConfig)
-    {
-        $this->proxyConfig = $proxyConfig;
-        $this->usingProxies = true;
-
-        return $this;
     }
 
     protected function getConfig()

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -476,7 +476,7 @@ class Crawler
                 continue;
             }
 
-            if ($poolItemLimit && $poolItemLimit >= $crawledUrlCount) {
+            if ($poolItemLimit && $poolItemLimit <= $crawledUrlCount) {
                 break;
             }
 

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -335,7 +335,7 @@ class Crawler
         return $this->baseUrl;
     }
 
-    public function setProxies(array $proxyConfig)
+    public function setProxies(array $proxyConfig): Crawler
     {
         $this->proxyConfig = $proxyConfig;
         $this->usingProxies = true;

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -444,7 +444,7 @@ class Crawler
         
         $proxyIp = $ips->random();
 
-        return "https://{$username}:{$password}@{$proxyIp}:{$port}";
+        return "tcp://{$username}:{$password}@{$proxyIp}:{$port}";
     }
 
     /**

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -50,6 +50,9 @@ class Crawler
     /** @var int|null */
     protected $maximumDepth = null;
 
+    /** @var int|null */
+    protected $poolItemLimit = null;
+
     /** @var bool */
     protected $respectRobots = true;
 

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -444,7 +444,7 @@ class Crawler
         
         $proxyIp = $ips->random();
 
-        return "tcp://{$username}:{$password}@{$proxyIp}:{$port}";
+        return "http://{$username}:{$password}@{$proxyIp}:{$port}";
     }
 
     /**


### PR DESCRIPTION
To effectively scrape certain sites that limit requests per IP I think the package should support randomized proxies. Since Guzzle only allows you to specify one proxy per client this is achieved at the `Pool` level, updating the request options (adding a random proxy) on each pool. 

Another caveat is that a very large pool will still have the same IP address sending requests in quick succession. To allow for the greatest flexibility here we've also add a `poolItemLimit` parameter that limits the pool size -- allowing you to rotate IP addresses down to each request. 

These are easily used in two functions:

**Setting Random Proxies Per Pool**

```
$crawler->setProxies([
    'ips' => '123.45.67.89,123.45.67.88,123.45.67.87...',
    'username' => 'laravel',
    'password' => 'secret',
    'port' => '12343',
])
```

**Limiting 1 Item Per Pool**

```
$crawler->setPoolItemLimit(1)