### PR TITLE
Documentation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ This package comes with three `CrawlProfiles` out of the box:
 
 - `CrawlAllUrls`: this profile will crawl all urls on all pages including urls to an external site.
 - `CrawlInternalUrls`: this profile will only crawl the internal urls on the pages of a host.
-- `CrawlSubdomainUrls`: this profile will only crawl the internal urls and its subdomains on the pages of a host.
+- `CrawlSubdomains`: this profile will only crawl the internal urls and its subdomains on the pages of a host.
 
 ### Ignoring robots.txt and robots meta
 


### PR DESCRIPTION
It seems that one of the CrawlProfiles is *CrawlSubdomains* not *CrawlSubdomainUrls*