### PR TITLE
The Crawler is handling relative paths after redirects incorrectly.

### DIFF
--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -3,11 +3,11 @@
 namespace Spatie\Crawler\Handlers;
 
 use GuzzleHttp\Psr7\Uri;
-use GuzzleHttp\RedirectMiddleware;
 use Spatie\Crawler\Crawler;
 use Spatie\Crawler\CrawlUrl;
 use Spatie\Crawler\LinkAdder;
 use Spatie\Crawler\CrawlerRobots;
+use GuzzleHttp\RedirectMiddleware;
 use Psr\Http\Message\UriInterface;
 use Spatie\Crawler\CrawlSubdomains;
 use Psr\Http\Message\StreamInterface;
@@ -59,7 +59,7 @@ class CrawlRequestFulfilled
 
         $historyHeader = $response->getHeader(RedirectMiddleware::HISTORY_HEADER);
         if (count($historyHeader) > 0) {
-            $lastRedirectUrl = $historyHeader[count($historyHeader)-1];
+            $lastRedirectUrl = $historyHeader[count($historyHeader) - 1];
             $baseUrl = new Uri($lastRedirectUrl);
         } else {
             $baseUrl = $crawlUrl->url;

--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -57,10 +57,9 @@ class CrawlRequestFulfilled
 
         $body = $this->convertBodyToString($response->getBody(), $this->crawler->getMaximumResponseSize());
 
-        $historyHeader = $response->getHeader(RedirectMiddleware::HISTORY_HEADER);
-        if (count($historyHeader) > 0) {
-            $lastRedirectUrl = $historyHeader[count($historyHeader) - 1];
-            $baseUrl = new Uri($lastRedirectUrl);
+        $redirectHistory = $response->getHeader(RedirectMiddleware::HISTORY_HEADER);
+        if (! empty($redirectHistory)) {
+            $baseUrl = new Uri(end($redirectHistory));
         } else {
             $baseUrl = $crawlUrl->url;
         }

--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -3,15 +3,15 @@
 namespace Spatie\Crawler\Handlers;
 
 use GuzzleHttp\Psr7\Uri;
-use GuzzleHttp\RedirectMiddleware;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\StreamInterface;
-use Psr\Http\Message\UriInterface;
 use Spatie\Crawler\Crawler;
-use Spatie\Crawler\CrawlerRobots;
-use Spatie\Crawler\CrawlSubdomains;
 use Spatie\Crawler\CrawlUrl;
 use Spatie\Crawler\LinkAdder;
+use Spatie\Crawler\CrawlerRobots;
+use GuzzleHttp\RedirectMiddleware;
+use Psr\Http\Message\UriInterface;
+use Spatie\Crawler\CrawlSubdomains;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\ResponseInterface;
 use function GuzzleHttp\Psr7\stream_for;
 
 class CrawlRequestFulfilled

--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -3,15 +3,15 @@
 namespace Spatie\Crawler\Handlers;
 
 use GuzzleHttp\Psr7\Uri;
+use GuzzleHttp\RedirectMiddleware;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
 use Spatie\Crawler\Crawler;
+use Spatie\Crawler\CrawlerRobots;
+use Spatie\Crawler\CrawlSubdomains;
 use Spatie\Crawler\CrawlUrl;
 use Spatie\Crawler\LinkAdder;
-use Spatie\Crawler\CrawlerRobots;
-use GuzzleHttp\RedirectMiddleware;
-use Psr\Http\Message\UriInterface;
-use Spatie\Crawler\CrawlSubdomains;
-use Psr\Http\Message\StreamInterface;
-use Psr\Http\Message\ResponseInterface;
 use function GuzzleHttp\Psr7\stream_for;
 
 class CrawlRequestFulfilled

--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -2,16 +2,16 @@
 
 namespace Spatie\Crawler\Test;
 
-use stdClass;
 use GuzzleHttp\Psr7\Uri;
-use Spatie\Crawler\Crawler;
 use GuzzleHttp\RequestOptions;
-use Spatie\Crawler\CrawlProfile;
 use Psr\Http\Message\UriInterface;
 use Spatie\Browsershot\Browsershot;
-use Spatie\Crawler\CrawlSubdomains;
+use Spatie\Crawler\Crawler;
 use Spatie\Crawler\CrawlInternalUrls;
+use Spatie\Crawler\CrawlProfile;
+use Spatie\Crawler\CrawlSubdomains;
 use Spatie\Crawler\Exception\InvalidCrawlRequestHandler;
+use stdClass;
 
 class CrawlerTest extends TestCase
 {

--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -2,24 +2,19 @@
 
 namespace Spatie\Crawler\Test;
 
+use stdClass;
 use GuzzleHttp\Psr7\Uri;
+use Spatie\Crawler\Crawler;
 use GuzzleHttp\RequestOptions;
+use Spatie\Crawler\CrawlProfile;
 use Psr\Http\Message\UriInterface;
 use Spatie\Browsershot\Browsershot;
-use Spatie\Crawler\Crawler;
-use Spatie\Crawler\CrawlInternalUrls;
-use Spatie\Crawler\CrawlProfile;
 use Spatie\Crawler\CrawlSubdomains;
+use Spatie\Crawler\CrawlInternalUrls;
 use Spatie\Crawler\Exception\InvalidCrawlRequestHandler;
-use stdClass;
 
 class CrawlerTest extends TestCase
 {
-    public static function log(string $text)
-    {
-        file_put_contents(static::$logPath, $text . PHP_EOL, FILE_APPEND);
-    }
-
     public function setUp()
     {
         parent::setUp();
@@ -39,23 +34,6 @@ class CrawlerTest extends TestCase
         $this->assertCrawledOnce($this->regularUrls());
 
         $this->assertNotCrawled($this->javascriptInjectedUrls());
-    }
-
-    protected function regularUrls(): array
-    {
-        return [
-            ['url' => 'http://localhost:8080/'],
-            ['url' => 'http://localhost:8080/link1', 'foundOn' => 'http://localhost:8080/'],
-            ['url' => 'http://localhost:8080/link1-prev', 'foundOn' => 'http://localhost:8080/link1'],
-            ['url' => 'http://localhost:8080/link1-next', 'foundOn' => 'http://localhost:8080/link1'],
-            ['url' => 'http://localhost:8080/link2', 'foundOn' => 'http://localhost:8080/'],
-            ['url' => 'http://localhost:8080/link3', 'foundOn' => 'http://localhost:8080/link2'],
-            ['url' => 'http://localhost:8080/notExists', 'foundOn' => 'http://localhost:8080/link3'],
-            ['url' => 'http://example.com/', 'foundOn' => 'http://localhost:8080/link1'],
-            ['url' => 'http://localhost:8080/dir/link4', 'foundOn' => 'http://localhost:8080/'],
-            ['url' => 'http://localhost:8080/dir/link5', 'foundOn' => 'http://localhost:8080/dir/link4'],
-            ['url' => 'http://localhost:8080/dir/subdir/link6', 'foundOn' => 'http://localhost:8080/dir/link5'],
-        ];
     }
 
     protected function javascriptInjectedUrls(): array
@@ -173,8 +151,7 @@ class CrawlerTest extends TestCase
     /** @test */
     public function it_uses_a_crawl_profile_to_determine_what_should_be_crawled()
     {
-        $crawlProfile = new class extends CrawlProfile
-        {
+        $crawlProfile = new class extends CrawlProfile {
             public function shouldCrawl(UriInterface $url): bool
             {
                 return $url->getPath() !== '/link3';
@@ -217,8 +194,7 @@ class CrawlerTest extends TestCase
     /** @test */
     public function it_can_handle_pages_with_invalid_urls()
     {
-        $crawlProfile = new class extends CrawlProfile
-        {
+        $crawlProfile = new class extends CrawlProfile {
             public function shouldCrawl(UriInterface $url): bool
             {
                 return true;
@@ -318,6 +294,11 @@ class CrawlerTest extends TestCase
         ]);
     }
 
+    public static function log(string $text)
+    {
+        file_put_contents(static::$logPath, $text . PHP_EOL, FILE_APPEND);
+    }
+
     /** @test */
     public function profile_crawls_a_domain_and_its_subdomains()
     {
@@ -394,6 +375,23 @@ class CrawlerTest extends TestCase
         $this->assertCrawledUrlCount(3);
     }
 
+    protected function regularUrls(): array
+    {
+        return [
+            ['url' => 'http://localhost:8080/'],
+            ['url' => 'http://localhost:8080/link1', 'foundOn' => 'http://localhost:8080/'],
+            ['url' => 'http://localhost:8080/link1-prev', 'foundOn' => 'http://localhost:8080/link1'],
+            ['url' => 'http://localhost:8080/link1-next', 'foundOn' => 'http://localhost:8080/link1'],
+            ['url' => 'http://localhost:8080/link2', 'foundOn' => 'http://localhost:8080/'],
+            ['url' => 'http://localhost:8080/link3', 'foundOn' => 'http://localhost:8080/link2'],
+            ['url' => 'http://localhost:8080/notExists', 'foundOn' => 'http://localhost:8080/link3'],
+            ['url' => 'http://example.com/', 'foundOn' => 'http://localhost:8080/link1'],
+            ['url' => 'http://localhost:8080/dir/link4', 'foundOn' => 'http://localhost:8080/'],
+            ['url' => 'http://localhost:8080/dir/link5', 'foundOn' => 'http://localhost:8080/dir/link4'],
+            ['url' => 'http://localhost:8080/dir/subdir/link6', 'foundOn' => 'http://localhost:8080/dir/link5'],
+        ];
+    }
+
     /** @test */
     public function it_respects_the_requested_delay_between_requests()
     {
@@ -404,7 +402,7 @@ class CrawlerTest extends TestCase
         Crawler::create()
             ->setCrawlObserver(new CrawlLogger())
             ->setMaximumDepth(2)
-            ->setDelayBetweenRequests(500)// 500ms
+            ->setDelayBetweenRequests(500) // 500ms
             ->setCrawlProfile(new CrawlSubdomains($baseUrl))
             ->startCrawling($baseUrl);
 

--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -296,7 +296,7 @@ class CrawlerTest extends TestCase
 
     public static function log(string $text)
     {
-        file_put_contents(static::$logPath, $text . PHP_EOL, FILE_APPEND);
+        file_put_contents(static::$logPath, $text.PHP_EOL, FILE_APPEND);
     }
 
     /** @test */

--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -2,16 +2,16 @@
 
 namespace Spatie\Crawler\Test;
 
+use stdClass;
 use GuzzleHttp\Psr7\Uri;
+use Spatie\Crawler\Crawler;
 use GuzzleHttp\RequestOptions;
+use Spatie\Crawler\CrawlProfile;
 use Psr\Http\Message\UriInterface;
 use Spatie\Browsershot\Browsershot;
-use Spatie\Crawler\Crawler;
-use Spatie\Crawler\CrawlInternalUrls;
-use Spatie\Crawler\CrawlProfile;
 use Spatie\Crawler\CrawlSubdomains;
+use Spatie\Crawler\CrawlInternalUrls;
 use Spatie\Crawler\Exception\InvalidCrawlRequestHandler;
-use stdClass;
 
 class CrawlerTest extends TestCase
 {

--- a/tests/server/server.js
+++ b/tests/server/server.js
@@ -62,6 +62,18 @@ app.get('/meta-nofollow', function (request, response) {
     response.end('<html><head>\n<meta name="robots" content="index, nofollow">\n</head><body><a href="/meta-nofollow-target">no follow it</a></body></html>');
 });
 
+app.get('/dir1/infernal-redirect-entry/', function (request, response) {
+    response.end('<a href="../loop-generator/infernal-redirect/trapped/">trapped</a> <a href="../../dir1/infernal-redirect/trap/">trap-start</a>');
+});
+
+app.get('/dir1/infernal-redirect/trap/', function (request, response) {
+    response.redirect(301, '/dir1/infernal-redirect-entry/');
+});
+
+app.get('/dir1/loop-generator/infernal-redirect/trapped/', function (request, response) {
+    response.end('It should be crawled once');
+});
+
 app.get('/meta-nofollow-target', function (request, response) {
     response.end('No followable');
 });


### PR DESCRIPTION
Hi!
I've discovered the crawler is handling incorrectly relative paths after redirects. When the redirect happens, all links are extracted as if the foundOn was the original url instead of the last url. This solution will try to take advantage of guzzle's X-Guzzle-Redirect-History header.