### PR TITLE
CollectionCrawlQueue::has() does not accept string

### DIFF
--- a/src/CrawlQueue/CollectionCrawlQueue.php
+++ b/src/CrawlQueue/CollectionCrawlQueue.php
@@ -77,7 +77,7 @@ class CollectionCrawlQueue implements CrawlQueue
     }
 
     /**
-     * @param CrawlUrl|\Psr\Http\Message\UriInterface|string $crawlUrl
+     * @param CrawlUrl|\Psr\Http\Message\UriInterface $crawlUrl
      *
      * @return bool
      */


### PR DESCRIPTION
If `$crawlUrl` is not an instance of `CrawlUrl`, `CrawlUrl::create()` is used, and it only accepts a `UriInterface`.
So the actual allowed types are `CrawlUrl|UriInterface`.