### PR TITLE
Implement retries

### DIFF
--- a/src/CrawlQueue/CollectionCrawlQueue.php
+++ b/src/CrawlQueue/CollectionCrawlQueue.php
@@ -5,7 +5,7 @@ namespace Spatie\Crawler\CrawlQueue;
 use Spatie\Crawler\CrawlUrl;
 use Spatie\Crawler\Exception\UrlNotFoundByIndex;
 
-class CollectionCrawlQueue implements CrawlQueue
+class CollectionCrawlQueue implements RetryableCrawlQueue
 {
     /** @var \Illuminate\Support\Collection|\Tightenco\Collect\Support\Collection */
     protected $urls;
@@ -115,5 +115,23 @@ class CollectionCrawlQueue implements CrawlQueue
         }
 
         return false;
+    }
+
+    /**
+     * @param CrawlUrl $crawlUrl
+     *
+     * @return void
+     */
+    public function retry(CrawlUrl $crawlUrl)
+    {
+        if (! $this->contains($this->urls, $crawlUrl)) {
+            return;
+        }
+
+        if ($this->contains($this->pendingUrls, $crawlUrl)) {
+            return;
+        }
+
+        $this->pendingUrls->push($crawlUrl);
     }
 }

--- a/src/CrawlQueue/RetryableCrawlQueue.php
+++ b/src/CrawlQueue/RetryableCrawlQueue.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\Crawler\CrawlQueue;
+
+use Spatie\Crawler\CrawlUrl;
+
+/**
+ * This interface extends the base CrawlQueue for backwards compatibility with existing CrawlQueue implementations.
+ * An application requiring the retry feature (making use of the RetryProfile interface) must use a crawl queue that
+ * implements RetryableCrawlQueue. Note that the default crawl queue, CollectionCrawlQueue, already implements this
+ * interface.
+ *
+ * @todo v5: merge this interface with CrawlQueue
+ */
+interface RetryableCrawlQueue extends CrawlQueue
+{
+    /**
+     * Puts the given URL back in the pending URLs queue.
+     * If the URL is not known or is already in the pending queue, this method does nothing.
+     *
+     * @param CrawlUrl $crawlUrl
+     *
+     * @return void
+     */
+    public function retry(CrawlUrl $crawlUrl);
+}

--- a/src/CrawlUrl.php
+++ b/src/CrawlUrl.php
@@ -15,6 +15,9 @@ class CrawlUrl
     /** @var mixed */
     protected $id;
 
+    /** @var int */
+    protected $attempts = 0;
+
     public static function create(UriInterface $url, ?UriInterface $foundOnUrl = null, $id = null)
     {
         $static = new static($url, $foundOnUrl);
@@ -43,5 +46,23 @@ class CrawlUrl
     public function setId($id)
     {
         $this->id = $id;
+    }
+
+    /**
+     * Returns the number of attempts to load this URL.
+     *
+     * @return int
+     */
+    public function getAttempts() : int
+    {
+        return $this->attempts;
+    }
+
+    /**
+     * @return void
+     */
+    public function incrementAttempts()
+    {
+        $this->attempts++;
     }
 }

--- a/src/RetryProfile.php
+++ b/src/RetryProfile.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\Crawler;
+
+use GuzzleHttp\Exception\RequestException;
+
+interface RetryProfile
+{
+    /**
+     * Returns whether a given request should be retried.
+     *
+     * Note: when using a custom implementation of CrawlQueue, ensure that your class implements RetryableCrawlQueue
+     * instead of CrawlQueue to make use of the retry feature, or retries will not be executed.
+     *
+     * If you're using the default CollectionCrawlQueue, you're all set.
+     *
+     * @param CrawlUrl         $crawlUrl  The failed URL. Contains the number of attempts to load it.
+     * @param RequestException $exception The Guzzle exception that occurred while performing the request.
+     *
+     * @return bool
+     */
+    public function shouldRetry(CrawlUrl $crawlUrl, RequestException $exception) : bool;
+}

--- a/src/RetryProfile/NoRetry.php
+++ b/src/RetryProfile/NoRetry.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\Crawler\RetryProfile;
+
+use Spatie\Crawler\CrawlUrl;
+use Spatie\Crawler\RetryProfile;
+use GuzzleHttp\Exception\RequestException;
+
+class NoRetry implements RetryProfile
+{
+    public function shouldRetry(CrawlUrl $url, RequestException $exception) : bool
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
This is a working, **backwards-compatible** implementation of the retry feature suggested in #233.

Example usage:

```php
$retryProfile = new class implements \Spatie\Crawler\RetryProfile
{
    public function shouldRetry(CrawlUrl $crawlUrl, RequestException $exception): bool
    {
        $response = $exception->getResponse();

        // only retry network errors and 5xx server errors
        if ($response !== null && $response->getStatusCode() < 500) {
            return false;
        }

        // maximum 5 attempts
        return $crawlUrl->getAttempts() < 5;
    }
};

Crawler::create($options)
    ->setRetryProfile($retryProfile)
    ->startCrawling($url);
```

### Why this feature?

As suggested by @Redominus in the related issue, one could use Guzzle's retry middleware instead. The issue is that this middleware performs consecutive retries **on the same URL**, leaving no time for any temporary glitch to resolve itself.

### What does this do instead?

If the `RetryProfile` in use instructs it to, the Crawler will push the failed URL back to the pending queue. The failed URL will be processed **after other pending URLs**, leaving more time between attempts, and avoiding a single URL to be considered a failure straight away in case the target server is down for a short amount of time.

This will also be useful when using a persistent crawl queue, such as a database-backed queue: the crawler can be interrupted at any time, and the failed URLs will persist in the pending queue.

This makes retries a first-class citizen, part of Crawler's core.

### What about backwards compatibility?

BC is fully preserved. The only tricky part was to extend the `CrawlQueue` interface, which misses a method to push a URL back to the pending queue.

The solution found was to extend it: `RetryableCrawlQueue` extends `CrawlQueue`, adding the method to support this feature. `CollectionCrawlQueue` now implements `RetryableCrawlQueue`, supporting the retry feature out-of-the-box.

For existing implementations of `CrawlQueue` that may be existing in the wild, they will continue to work as they did. If someone using a custom `CrawlQueue` attempts to make use of a `RetryProfile` without updating their crawl queue implementation, retries will just not be performed.

The `RetryProfile` docblock makes this very clear.

### Future scope

When BC can be broken (v5), `RetryableCrawlQueue` can be merged into `CrawlQueue`.
A `@todo` was left in the source code to remember this.

---

@Redominus @freekmurze @brendt Looking forward to your feedback! 👍 