### PR TITLE
Fix $delayBetweenRequests type, add doc

### DIFF
--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -71,7 +71,7 @@ class Crawler
     /** @var string */
     protected $crawlRequestFailedClass;
 
-    /** @var float */
+    /** @var int */
     protected $delayBetweenRequests = 0;
 
     /** @var   */
@@ -158,6 +158,11 @@ class Crawler
         return $this->maximumDepth;
     }
 
+    /**
+     * @param int $delay The delay in milliseconds.
+     *
+     * @return Crawler
+     */
     public function setDelayBetweenRequests(int $delay): Crawler
     {
         $this->delayBetweenRequests = ($delay * 1000);
@@ -165,7 +170,10 @@ class Crawler
         return $this;
     }
 
-    public function getDelayBetweenRequests(): float
+    /**
+     * @return int The delay in milliseconds.
+     */
+    public function getDelayBetweenRequests(): int
     {
         return $this->delayBetweenRequests;
     }


### PR DESCRIPTION
`$delayBetweenRequests` is only set from within `setDelayBetweenRequests()`, which is type-hinted as `int`. So this property can never be a `float`.

`getDelayBetweenRequests()` should not implicitly convert it to a `float`, as it's only used by `usleep()`, which accepts an `int`.

This yields a useless implicit conversion chain from `int` => `float` => `int`.

I've also added a doc to state that it accepts a number of *milliseconds*, which is otherwise not documented.

Note that *this is a small BC break*, in case someone overrides the non-final `getDelayBetweenRequests()` method - which is unlikely, but still, I'm not sure whether this is acceptable for you to release in a minor or patch version.
