### PR TITLE
[v5] Get rid of CrawlUrl::$id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to `spatie/crawler` will be documented in this file.
 
+## Unreleased (5.0.0)
+
+Breaking changes:
+
+- exception `UrlNotFoundByIndex` has been renamed to `UrlNotFound`
+- method `CrawlQueue::getUrlById()` has been removed
+- new method `CrawlQueue::get()` has been added
+- property `CrawlUrl::$id` and getter/setter have been removed
+
 ## 4.4.3 - 2019-06-22
 
 - `delayBetweenRequests` now uses `int` instead of `float` everywhere

--- a/src/CrawlQueue/CollectionCrawlQueue.php
+++ b/src/CrawlQueue/CollectionCrawlQueue.php
@@ -3,7 +3,7 @@
 namespace Spatie\Crawler\CrawlQueue;
 
 use Spatie\Crawler\CrawlUrl;
-use Spatie\Crawler\Exception\UrlNotFoundByIndex;
+use Spatie\Crawler\Exception\UrlNotFound;
 
 class CollectionCrawlQueue implements CrawlQueue
 {
@@ -36,9 +36,7 @@ class CollectionCrawlQueue implements CrawlQueue
             return $this;
         }
 
-        $this->urls->push($url);
-
-        $url->setId($this->urls->keys()->last());
+        $this->urls[(string) $url->url] = $url;
         $this->pendingUrls->push($url);
 
         return $this;
@@ -50,17 +48,17 @@ class CollectionCrawlQueue implements CrawlQueue
     }
 
     /**
-     * @param mixed $id
+     * @param string $url
      *
-     * @return \Spatie\Crawler\CrawlUrl|null
+     * @return \Spatie\Crawler\CrawlUrl
      */
-    public function getUrlById($id): CrawlUrl
+    public function get(string $url): CrawlUrl
     {
-        if (! isset($this->urls->values()[$id])) {
-            throw new UrlNotFoundByIndex("#{$id} crawl url not found in collection");
+        if (! isset($this->urls[$url])) {
+            throw new UrlNotFound("Crawl url $url not found in collection");
         }
 
-        return $this->urls->values()[$id];
+        return $this->urls[$url];
     }
 
     public function hasAlreadyBeenProcessed(CrawlUrl $url): bool

--- a/src/CrawlQueue/CrawlQueue.php
+++ b/src/CrawlQueue/CrawlQueue.php
@@ -12,7 +12,7 @@ interface CrawlQueue
 
     public function hasPendingUrls(): bool;
 
-    public function getUrlById($id): CrawlUrl;
+    public function get(string $url): CrawlUrl;
 
     /** @return \Spatie\Crawler\CrawlUrl|null */
     public function getFirstPendingUrl();

--- a/src/CrawlUrl.php
+++ b/src/CrawlUrl.php
@@ -12,16 +12,9 @@ class CrawlUrl
     /** @var \Psr\Http\Message\UriInterface */
     public $foundOnUrl;
 
-    /** @var mixed */
-    protected $id;
-
-    public static function create(UriInterface $url, ?UriInterface $foundOnUrl = null, $id = null)
+    public static function create(UriInterface $url, ?UriInterface $foundOnUrl = null)
     {
         $static = new static($url, $foundOnUrl);
-
-        if ($id !== null) {
-            $static->setId($id);
-        }
 
         return $static;
     }
@@ -30,18 +23,5 @@ class CrawlUrl
     {
         $this->url = $url;
         $this->foundOnUrl = $foundOnUrl;
-    }
-
-    /**
-     * @return mixed|null
-     */
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    public function setId($id)
-    {
-        $this->id = $id;
     }
 }

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -440,7 +440,7 @@ class Crawler
 
             $this->crawlQueue->markAsProcessed($crawlUrl);
 
-            yield $crawlUrl->getId() => new Request('GET', $crawlUrl->url);
+            yield ((string) $crawlUrl->url) => new Request('GET', $crawlUrl->url);
         }
     }
 

--- a/src/Exception/UrlNotFound.php
+++ b/src/Exception/UrlNotFound.php
@@ -4,6 +4,6 @@ namespace Spatie\Crawler\Exception;
 
 use RuntimeException;
 
-class UrlNotFoundByIndex extends RuntimeException
+class UrlNotFound extends RuntimeException
 {
 }

--- a/src/Handlers/CrawlRequestFailed.php
+++ b/src/Handlers/CrawlRequestFailed.php
@@ -15,9 +15,9 @@ class CrawlRequestFailed
         $this->crawler = $crawler;
     }
 
-    public function __invoke(RequestException $exception, $index)
+    public function __invoke(RequestException $exception, string $url)
     {
-        $crawlUrl = $this->crawler->getCrawlQueue()->getUrlById($index);
+        $crawlUrl = $this->crawler->getCrawlQueue()->get($url);
 
         $this->crawler->getCrawlObservers()->crawlFailed($crawlUrl, $exception);
 

--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -29,11 +29,11 @@ class CrawlRequestFulfilled
         $this->linkAdder = new LinkAdder($this->crawler);
     }
 
-    public function __invoke(ResponseInterface $response, $index)
+    public function __invoke(ResponseInterface $response, string $url)
     {
         $robots = new CrawlerRobots($response, $this->crawler->mustRespectRobots());
 
-        $crawlUrl = $this->crawler->getCrawlQueue()->getUrlById($index);
+        $crawlUrl = $this->crawler->getCrawlQueue()->get($url);
 
         if ($this->crawler->mayExecuteJavaScript()) {
             $html = $this->getBodyAfterExecutingJavaScript($crawlUrl->url);

--- a/tests/CrawlQueueTest.php
+++ b/tests/CrawlQueueTest.php
@@ -48,11 +48,11 @@ class CrawlQueueTest extends TestCase
 
         $this->assertEquals(
             'https://example1.com/',
-            (string) $this->crawlQueue->getUrlById($url1->getId())->url
+            (string) $this->crawlQueue->get('https://example1.com/')->url
         );
         $this->assertEquals(
             'https://example2.com/',
-            (string) $this->crawlQueue->getUrlById($url2->getId())->url
+            (string) $this->crawlQueue->get('https://example2.com/')->url
         );
     }
 


### PR DESCRIPTION
Guzzle's Pool allows string keys, allowing us to use the URL as the key, and avoiding the need for a numeric ID in `CrawlUrl`.

*This PR targets `master` for now, but I think the project should be branched to `v5` and this PR retargeted.*