### PR TITLE
Fix bugs related to changing the user agent header

### DIFF
--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -20,7 +20,7 @@ use Spatie\Crawler\Exception\InvalidCrawlRequestHandler;
 
 class Crawler
 {
-    public const DEFAULT_USER_AGENT = 'SpatieCrawler/4.5';
+    public const DEFAULT_USER_AGENT = '*';
 
     /** @var \GuzzleHttp\Client */
     protected $client;

--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -425,4 +425,16 @@ class CrawlerTest extends TestCase
 
         Crawler::create()->setCrawlFailedHandlerClass(stdClass::class);
     }
+
+    /** @test */
+    public function it_should_ignore_user_agents_header_case()
+    {
+        $clientConfig = ['headers' => ['user-agent' => 'foo']];
+        $newUserAgent = 'bar';
+
+        $crawler = Crawler::create($clientConfig)->setUserAgent($newUserAgent);
+        $actualUserAgent = $crawler->getUserAgent();
+
+        $this->assertSame($newUserAgent, $actualUserAgent);
+    }
 }


### PR DESCRIPTION
This fixes some issues introduced in the 4.5.0 release (https://github.com/spatie/crawler/pull/246).
Header names are [not case sensitive](https://tools.ietf.org/html/rfc7230#section-3.2) and yet `Notice: Undefined index: User-Agent` occurs when trying to crawl using Crawler created with configuration such as:
```php
Crawler::create(['headers' => ['user-agent' => 'WhatEver/1.0']]);
```