### PR TITLE
Faster default crawl queue implementation

### DIFF
--- a/src/CrawlQueue/ArrayCrawlQueue.php
+++ b/src/CrawlQueue/ArrayCrawlQueue.php
@@ -2,10 +2,10 @@
 
 namespace Spatie\Crawler\CrawlQueue;
 
-use Psr\Http\Message\UriInterface;
-use Spatie\Crawler\CrawlUrl;
-use Spatie\Crawler\Exception\UrlNotFoundByIndex;
 use TypeError;
+use Spatie\Crawler\CrawlUrl;
+use Psr\Http\Message\UriInterface;
+use Spatie\Crawler\Exception\UrlNotFoundByIndex;
 
 /**
  * Crawl queue implemented with arrays.
@@ -77,7 +77,7 @@ class ArrayCrawlQueue implements CrawlQueue
     {
         if ($crawlUrl instanceof CrawlUrl) {
             $url = (string) $crawlUrl->url;
-        } else if ($crawlUrl instanceof UriInterface) {
+        } elseif ($crawlUrl instanceof UriInterface) {
             $url = (string) $crawlUrl;
         } else {
             throw new TypeError(sprintf(

--- a/src/CrawlQueue/ArrayCrawlQueue.php
+++ b/src/CrawlQueue/ArrayCrawlQueue.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Spatie\Crawler\CrawlQueue;
+
+use Psr\Http\Message\UriInterface;
+use Spatie\Crawler\CrawlUrl;
+use Spatie\Crawler\Exception\UrlNotFoundByIndex;
+use TypeError;
+
+/**
+ * Crawl queue implemented with arrays.
+ */
+class ArrayCrawlQueue implements CrawlQueue
+{
+    /**
+     * All known URLs, indexed by URL string.
+     *
+     * @var CrawlUrl[]
+     */
+    protected $urls = [];
+
+    /**
+     * Pending URLs, indexed by URL string.
+     *
+     * @var CrawlUrl[]
+     */
+    protected $pendingUrls = [];
+
+    public function add(CrawlUrl $url) : CrawlQueue
+    {
+        $urlString = (string) $url->url;
+
+        if (! isset($this->urls[$urlString])) {
+            $url->setId($urlString);
+
+            $this->urls[$urlString] = $url;
+            $this->pendingUrls[$urlString] = $url;
+        }
+
+        return $this;
+    }
+
+    public function hasPendingUrls() : bool
+    {
+        return (bool) $this->pendingUrls;
+    }
+
+    public function getUrlById($id) : CrawlUrl
+    {
+        if (! isset($this->urls[$id])) {
+            throw new UrlNotFoundByIndex("Crawl url $id not found in collection.");
+        }
+
+        return $this->urls[$id];
+    }
+
+    public function hasAlreadyBeenProcessed(CrawlUrl $url) : bool
+    {
+        $url = (string) $url->url;
+
+        return ! isset($this->pendingUrls[$url]) && isset($this->pendingUrls[$url]);
+    }
+
+    public function markAsProcessed(CrawlUrl $crawlUrl)
+    {
+        $url = (string) $crawlUrl->url;
+
+        unset($this->pendingUrls[$url]);
+    }
+
+    /**
+     * @param CrawlUrl|UriInterface $crawlUrl
+     *
+     * @return bool
+     */
+    public function has($crawlUrl) : bool
+    {
+        if ($crawlUrl instanceof CrawlUrl) {
+            $url = (string) $crawlUrl->url;
+        } else if ($crawlUrl instanceof UriInterface) {
+            $url = (string) $crawlUrl;
+        } else {
+            throw new TypeError(sprintf(
+                'Expected %s or %s, got %s.',
+                CrawlUrl::class,
+                UriInterface::class,
+                is_object($crawlUrl) ? get_class($crawlUrl) : gettype($crawlUrl)
+            ));
+        }
+
+        return isset($this->urls[$url]);
+    }
+
+    public function getFirstPendingUrl() : ?CrawlUrl
+    {
+        foreach ($this->pendingUrls as $pendingUrl) {
+            return $pendingUrl;
+        }
+
+        return null;
+    }
+}

--- a/src/CrawlQueue/CollectionCrawlQueue.php
+++ b/src/CrawlQueue/CollectionCrawlQueue.php
@@ -5,6 +5,9 @@ namespace Spatie\Crawler\CrawlQueue;
 use Spatie\Crawler\CrawlUrl;
 use Spatie\Crawler\Exception\UrlNotFoundByIndex;
 
+/**
+ * @deprecated Use ArrayCrawlQueue
+ */
 class CollectionCrawlQueue implements CrawlQueue
 {
     /** @var \Illuminate\Support\Collection|\Tightenco\Collect\Support\Collection */

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -13,9 +13,9 @@ use GuzzleHttp\RequestOptions;
 use Psr\Http\Message\UriInterface;
 use Spatie\Browsershot\Browsershot;
 use Spatie\Crawler\CrawlQueue\CrawlQueue;
+use Spatie\Crawler\CrawlQueue\ArrayCrawlQueue;
 use Spatie\Crawler\Handlers\CrawlRequestFailed;
 use Spatie\Crawler\Handlers\CrawlRequestFulfilled;
-use Spatie\Crawler\CrawlQueue\ArrayCrawlQueue;
 use Spatie\Crawler\Exception\InvalidCrawlRequestHandler;
 
 class Crawler

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -15,7 +15,7 @@ use Spatie\Browsershot\Browsershot;
 use Spatie\Crawler\CrawlQueue\CrawlQueue;
 use Spatie\Crawler\Handlers\CrawlRequestFailed;
 use Spatie\Crawler\Handlers\CrawlRequestFulfilled;
-use Spatie\Crawler\CrawlQueue\CollectionCrawlQueue;
+use Spatie\Crawler\CrawlQueue\ArrayCrawlQueue;
 use Spatie\Crawler\Exception\InvalidCrawlRequestHandler;
 
 class Crawler
@@ -101,7 +101,7 @@ class Crawler
 
         $this->crawlProfile = new CrawlAllUrls();
 
-        $this->crawlQueue = new CollectionCrawlQueue();
+        $this->crawlQueue = new ArrayCrawlQueue();
 
         $this->crawlObservers = new CrawlObserverCollection();
 


### PR DESCRIPTION
🐌 **The issue with the collection crawl queue**

The default crawl queue is currently based on Illuminate Collections, and suffers from many flaws that make it slow: it [loops through entire collections to find objects, and makes ultra-heavy use of `Uri`-to-string conversions](https://github.com/spatie/crawler/blob/c5a351bf1859dfdbe46dac67bc22f26759de00c3/src/CrawlQueue/CollectionCrawlQueue.php#L111-L115):

```php
foreach ($collection as $crawlUrl) {
    if ((string) $crawlUrl->url === (string) $searchCrawlUrl->url) {
        return true;
    }
}
```

This implementation works fine for crawling small websites (< 1000 pages); after that, the crawler starts to be CPU-bound (~100% CPU usage) and starts slowing down.

After a few thousand pages, it almost comes to a halt, and takes something like 15 seconds to move from one page to another. This delay raises exponentially with the number of pages in the queue.

:rocket: **NEW: the array crawl queue**

This PR brings a 100% compatible implementation:

- based on native arrays; no more Collection overhead (wrapping, copying, filtering);
- indexed by URL: we can instantly find a given URL with a lookup, without having to loop through the collection;
- `CrawlUrl` ids are strings, using the full URL and no more artificial integer keys to lookup;
- Shortcuts: no more `contains()`, we can now use `isset()` directly.

💨 **Is is faster?**

It *is* faster. Much, **MUCH** faster. When the original implementation almost came to a halt after a few thousand pages, the new implementation is still performing 10 requests per second after 40,000 pages, and is not even CPU bound.

**That's what I suggest we make this new crawl queue the default right away, and deprecate the other one.**

---

This PR is 100% backwards compatible, and as such does not need to wait for [v5](https://github.com/spatie/crawler/issues/243).

In v5, we might want to remove the dependency on Illuminate Collections entirely. This was a noble idea, but `Collection` is overkill for this use case.