### PR TITLE
Fix inversion of logic & property name typo

### DIFF
--- a/src/CrawlQueue/ArrayCrawlQueue.php
+++ b/src/CrawlQueue/ArrayCrawlQueue.php
@@ -59,11 +59,11 @@ class ArrayCrawlQueue implements CrawlQueue
             return false;
         }
 
-        if (isset($this->url[$url])) {
-            return false;
+        if (isset($this->urls[$url])) {
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     public function markAsProcessed(CrawlUrl $crawlUrl)

--- a/tests/ArrayCrawlQueueTest.php
+++ b/tests/ArrayCrawlQueueTest.php
@@ -8,7 +8,7 @@ use Spatie\Crawler\CrawlQueue\ArrayCrawlQueue;
 
 class ArrayCrawlQueueTest extends TestCase
 {
-    /** @var \Spatie\Crawler\CrawlQueue\CollectionCrawlQueue */
+    /** @var \Spatie\Crawler\CrawlQueue\ArrayCrawlQueue */
     protected $crawlQueue;
 
     public function setUp()
@@ -72,6 +72,8 @@ class ArrayCrawlQueueTest extends TestCase
     public function it_can_mark_an_url_as_processed()
     {
         $crawlUrl = $this->createCrawlUrl('https://example1.com/');
+
+        $this->assertFalse($this->crawlQueue->hasAlreadyBeenProcessed($crawlUrl));
 
         $this->crawlQueue->add($crawlUrl);
 


### PR DESCRIPTION
Just noticed 2 gross bugs that need a urgent fix:

- There was a logic inversion: it must return `true` if the URL is present in `$this->urls`
- `$this->urls` has been mispelt as `$this->url`, which went unnoticed due to `isset()`

I also updated the tests to catch this.

Could you please merge and tag a release ASAP? Thank you!