### PR TITLE
RedisCrawlQueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,28 @@ Crawler::create()
     ->setCrawlQueue(<implementation of \Spatie\Crawler\CrawlQueue\CrawlQueue>)
 ```
 
+#### Available Queues
+* ArrayCrawlQueue (PHP arrays)
+* CollectionCrawlQueue (`Illuminate\Support\Collection` or `Tightenco\Collect\Support\Collection`)
+* RedisCrawlQueue (via [predis/predis](https://packagist.org/packages/predis/predis))
+
+##### RedisCrawlQueue
+Create a `Predis\Client` beforehand if you need options, such as selecting a database. If you don't pass a client, a new one without options will be used. Predis assumes `127.0.0.1`, `6379` and `0` as default host, port and database.
+
+```php
+// see https://github.com/nrk/predis for options
+$options = [
+    'database' => 7,
+];
+$redisClient = new \Predis\Client($options);
+
+// ...
+->setCrawlQueue(new RedisCrawlQueue($redisClient))
+
+// uses new \Predis\Client without options
+->setCrawlQueue(new RedisCrawlQueue())
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",
-        "larapack/dd": "^1.1"
+        "larapack/dd": "^1.1",
+        "predis/predis": "^1.1"
     },
     "autoload": {
         "psr-4": {
@@ -49,5 +50,8 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "suggest": {
+        "predis/predis": "Using RedisCrawlQueue"
     }
 }

--- a/src/CrawlQueue/RedisCrawlQueue.php
+++ b/src/CrawlQueue/RedisCrawlQueue.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Spatie\Crawler\CrawlQueue;
+
+use Predis\Client;
+use Psr\Http\Message\UriInterface;
+use Spatie\Crawler\CrawlUrl;
+use Spatie\Crawler\Exception\InvalidUrl;
+use Spatie\Crawler\Exception\UrlNotFoundByIndex;
+
+/**
+ * Implementation of CrawlQueue using Redis Hashes
+ */
+class RedisCrawlQueue implements CrawlQueue
+{
+    // All known URLs, indexed by URL string.
+    const URLS = 'urls';
+    // Pending URLs, indexed by URL string.
+    const PENDING_URLS = 'pending';
+
+    /**
+     * Redis Instance
+     * @var \Predis\Client
+     */
+    private $redis;
+
+    public function __construct(?Client $redis = null)
+    {
+        $this->redis = $redis;
+        if (is_null($redis)) {
+            $this->redis = new Client();
+        }
+    }
+
+    public function add(CrawlUrl $url) : CrawlQueue
+    {
+        $urlString = (string) $url->url;
+
+        if (!$this->has($urlString)) {
+            $url->setId($urlString);
+
+            $this->redis->hset(self::URLS, $urlString, serialize($url));
+            $this->redis->hset(self::PENDING_URLS, $urlString, serialize($url));
+        }
+
+        return $this;
+    }
+
+    public function has($crawlUrl) : bool
+    {
+        if ($crawlUrl instanceof CrawlUrl) {
+            $url = (string) $crawlUrl->url;
+        } elseif ($crawlUrl instanceof UriInterface) {
+            $url = (string) $crawlUrl;
+        } elseif (is_string($crawlUrl)) {
+            $url = $crawlUrl;
+        } else {
+            throw InvalidUrl::unexpectedType($crawlUrl);
+        }
+
+        return (bool) $this->redis->hexists(self::URLS, $url);
+    }
+
+    public function hasPendingUrls() : bool
+    {
+        return (bool) $this->redis->hlen(self::PENDING_URLS);
+    }
+
+    public function getUrlById($id) : CrawlUrl
+    {
+        if (!$this->has($id)) {
+            throw new UrlNotFoundByIndex("Crawl url {$id} not found in hashes.");
+        }
+        return unserialize($this->redis->hget(self::URLS, $id));
+    }
+
+    public function getFirstPendingUrl() : ?CrawlUrl
+    {
+        $keys = $this->redis->hkeys(self::PENDING_URLS);
+
+        foreach ($keys as $key) {
+            return unserialize($this->redis->hget(self::PENDING_URLS, $key));
+        }
+
+        return null;
+    }
+
+    public function hasAlreadyBeenProcessed(CrawlUrl $url) : bool
+    {
+        $url = (string) $url->url;
+
+        if ($this->redis->hexists(self::PENDING_URLS, $url)) {
+            return false;
+        }
+
+        if ($this->redis->hexists(self::URLS, $url)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function markAsProcessed(CrawlUrl $crawlUrl)
+    {
+        $this->redis->hdel(self::PENDING_URLS, (string) $crawlUrl->url);
+    }
+}

--- a/tests/RedisCrawlQueueTest.php
+++ b/tests/RedisCrawlQueueTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Spatie\Crawler\Test;
+
+use GuzzleHttp\Psr7\Uri;
+use Predis\Client;
+use Spatie\Crawler\CrawlQueue\RedisCrawlQueue;
+use Spatie\Crawler\CrawlUrl;
+
+class RedisCrawlQueueTest extends TestCase
+{
+    /** @var \Spatie\Crawler\CrawlQueue\RedisCrawlQueue */
+    protected $crawlQueue;
+    /** @var \Predis\Client */
+    protected $client;
+    /**
+     * Maximum number of Redis DBs out of the box
+     * see http://download.redis.io/redis-stable/redis.conf
+     * @var integer
+     */
+    const MAX_REDIS_DB_OOTB = 16;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        // try not to interfere for other applications
+        for ($dbNr = 0; $dbNr < self::MAX_REDIS_DB_OOTB; $dbNr++) {
+            $this->client = new Client(['database' => $dbNr]);
+
+            // try to find an empty DB
+            if ($this->client->dbsize() === 0) {
+                break;
+            }
+        }
+
+        $this->crawlQueue = new RedisCrawlQueue($this->client);
+    }
+
+    /** @test */
+    public function an_url_can_be_added()
+    {
+        $status = $this->client->flushdb();
+
+        $crawlUrl = $this->createCrawlUrl('https://example.com');
+        $this->crawlQueue->add($crawlUrl);
+
+        $this->assertEquals($crawlUrl, $this->crawlQueue->getFirstPendingUrl());
+    }
+
+    /** @test */
+    public function it_can_determine_if_there_are_pending_urls()
+    {
+        $this->client->flushdb();
+
+        $this->assertFalse($this->crawlQueue->hasPendingUrls());
+
+        $this->crawlQueue->add($this->createCrawlUrl('https://example.com'));
+
+        $this->assertTrue($this->crawlQueue->hasPendingUrls());
+    }
+
+    /** @test */
+    public function it_can_get_an_url_at_the_specified_index()
+    {
+        $this->client->flushdb();
+
+        $url1 = $this->createCrawlUrl('https://example1.com/');
+        $url2 = $this->createCrawlUrl('https://example2.com/');
+
+        $this->crawlQueue->add($url1);
+        $this->crawlQueue->add($url2);
+
+        $this->assertEquals(
+            'https://example1.com/',
+            (string) $this->crawlQueue->getUrlById($url1->getId())->url
+        );
+        $this->assertEquals(
+            'https://example2.com/',
+            (string) $this->crawlQueue->getUrlById($url2->getId())->url
+        );
+    }
+
+    /** @test */
+    public function it_can_determine_if_has_a_given_url()
+    {
+        $this->client->flushdb();
+
+        $crawlUrl = $this->createCrawlUrl('https://example1.com/');
+
+        $this->assertFalse($this->crawlQueue->has($crawlUrl));
+
+        $this->crawlQueue->add($crawlUrl);
+
+        $this->assertTrue($this->crawlQueue->has($crawlUrl));
+    }
+
+    /** @test */
+    public function it_can_mark_an_url_as_processed()
+    {
+        $this->client->flushdb();
+
+        $crawlUrl = $this->createCrawlUrl('https://example1.com/');
+
+        $this->assertFalse($this->crawlQueue->hasAlreadyBeenProcessed($crawlUrl));
+
+        $this->crawlQueue->add($crawlUrl);
+
+        $this->assertFalse($this->crawlQueue->hasAlreadyBeenProcessed($crawlUrl));
+
+        $this->crawlQueue->markAsProcessed($crawlUrl);
+
+        $this->assertTrue($this->crawlQueue->hasAlreadyBeenProcessed($crawlUrl));
+    }
+
+    /** @test */
+    public function it_can_remove_all_processed_urls_from_the_pending_urls()
+    {
+        $this->client->flushdb();
+        
+        $crawlUrl1 = $this->createCrawlUrl('https://example1.com/');
+        $crawlUrl2 = $this->createCrawlUrl('https://example2.com/');
+
+        $this->crawlQueue
+            ->add($crawlUrl1)
+            ->add($crawlUrl2);
+
+        $this->crawlQueue->markAsProcessed($crawlUrl1);
+
+        $pendingUrlCount = 0;
+
+        while ($url = $this->crawlQueue->getFirstPendingUrl()) {
+            $pendingUrlCount++;
+            $this->crawlQueue->markAsProcessed($url);
+        }
+
+        $this->assertEquals(1, $pendingUrlCount);
+    }
+
+    protected function createCrawlUrl(string $url): CrawlUrl
+    {
+        return CrawlUrl::create(new Uri($url));
+    }
+}


### PR DESCRIPTION
## Implementation of CrawlQueue using Redis Hashes via predis
* Test assumes Redis on localhost, tries to find an empty one not to interfere with other applications
* Added `suggest` to composer.json for predis/predis and `predis/predis ^1.1` to `require-dev`
* Added instructions to README
* If accepted could also write more flexible version with phpredis

![image](https://user-images.githubusercontent.com/516807/64240868-88bdfc00-ceb7-11e9-8b3f-da10e7ca3ffc.png)
