### PR TITLE
Improvement: if a broken URL was found on multiple sources, list all sources

### DIFF
--- a/src/CrawlQueue/ArrayCrawlQueue.php
+++ b/src/CrawlQueue/ArrayCrawlQueue.php
@@ -25,13 +25,13 @@ class ArrayCrawlQueue implements CrawlQueue
 
     public function add(CrawlUrl $url) : CrawlQueue
     {
-        $urlString = (string) $url->url;
+        $id = (string) $url->getId();
 
-        if (! isset($this->urls[$urlString])) {
-            $url->setId($urlString);
+        if (! isset($this->urls[$id])) {
+            $url->setId($id);
 
-            $this->urls[$urlString] = $url;
-            $this->pendingUrls[$urlString] = $url;
+            $this->urls[$id] = $url;
+            $this->pendingUrls[$id] = $url;
         }
 
         return $this;
@@ -53,13 +53,13 @@ class ArrayCrawlQueue implements CrawlQueue
 
     public function hasAlreadyBeenProcessed(CrawlUrl $url) : bool
     {
-        $url = (string) $url->url;
+        $id = (string) $url->getId();
 
-        if (isset($this->pendingUrls[$url])) {
+        if (isset($this->pendingUrls[$id])) {
             return false;
         }
 
-        if (isset($this->urls[$url])) {
+        if (isset($this->urls[$id])) {
             return true;
         }
 
@@ -68,9 +68,9 @@ class ArrayCrawlQueue implements CrawlQueue
 
     public function markAsProcessed(CrawlUrl $crawlUrl)
     {
-        $url = (string) $crawlUrl->url;
+        $id = (string) $crawlUrl->getId();
 
-        unset($this->pendingUrls[$url]);
+        unset($this->pendingUrls[$id]);
     }
 
     /**
@@ -81,7 +81,7 @@ class ArrayCrawlQueue implements CrawlQueue
     public function has($crawlUrl) : bool
     {
         if ($crawlUrl instanceof CrawlUrl) {
-            $url = (string) $crawlUrl->url;
+            $url = (string) $crawlUrl->getId();
         } elseif ($crawlUrl instanceof UriInterface) {
             $url = (string) $crawlUrl;
         } else {

--- a/src/CrawlUrl.php
+++ b/src/CrawlUrl.php
@@ -37,7 +37,7 @@ class CrawlUrl
      */
     public function getId()
     {
-        return $this->id;
+        return $this->id ?? $this->url . $this->foundOnUrl;
     }
 
     public function setId($id)

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -482,10 +482,6 @@ class Crawler
             return $this;
         }
 
-        if ($this->getCrawlQueue()->has($crawlUrl->url)) {
-            return $this;
-        }
-
         $this->crawledUrlCount++;
 
         $this->crawlQueue->add($crawlUrl);

--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -437,4 +437,20 @@ class CrawlerTest extends TestCase
 
         $this->assertSame($newUserAgent, $actualUserAgent);
     }
+
+    /** @test */
+    public function it_will_report_multiple_broken_pages_if_the_same_url_was_found_on_different_pages()
+    {
+        Crawler::create()
+            ->setCrawlObserver(new CrawlLogger())
+            ->startCrawling('http://localhost:8080/broken-link-root');
+
+        $this->assertCrawledOnce([
+            ['url' => 'http://localhost:8080/broken-link-root'],
+            ['url' => 'http://localhost:8080/broken-link-root/page1', 'foundOn' => 'http://localhost:8080/broken-link-root'],
+            ['url' => 'http://localhost:8080/broken-link-root/page2', 'foundOn' => 'http://localhost:8080/broken-link-root'],
+            ['url' => 'http://localhost:8080/this/does/not/exist', 'foundOn' => 'http://localhost:8080/broken-link-root/page1'],
+            ['url' => 'http://localhost:8080/this/does/not/exist', 'foundOn' => 'http://localhost:8080/broken-link-root/page2'],
+        ]);
+    }
 }

--- a/tests/server/server.js
+++ b/tests/server/server.js
@@ -88,6 +88,18 @@ app.get('/header-disallow', function (request, response) {
     response.end('disallow by header');
 });
 
+app.get('/broken-link-root', function (request, response) {
+    response.end('<html><body><a href="/broken-link-root/page1">page 1</a>, <a href="/broken-link-root/page2">page 2</a></body></html>');
+});
+
+app.get('/broken-link-root/page1', function (request, response) {
+    response.end('<html><body><a href="/this/does/not/exist">this will give a 404</a></body></html>');
+});
+
+app.get('/broken-link-root/page2', function (request, response) {
+    response.end('<html><body><a href="/this/does/not/exist">this will give a 404</a></body></html>');
+});
+
 app.get('/robots.txt', function (req, res) {
     var html = 'User-agent: *\n' +
         'Disallow: /txt-disallow\n' +


### PR DESCRIPTION
This fixes a situation like this:

```
http://localhost:9000/page1 - - +
                                |
                                |
                                + -- + --> http://localhost:9000/page3
                                |
                                |
http://localhost:9000/page2 - - +
```

2 pages both refer to a `/page3` URL. In the crawler results, it would only contain one instance for the `/page3` URL:

```
CrawledUrl {
  +crawledUrl: "http://localhost:9000/page3"
  +statusCode: 200
  +foundOnUrl: "http://localhost:9000/page1"
}
```

If we want to use the crawler to build a full graph of a website, linking every page/node to any other page/node, we need to store multiple `crawledUrl` & `foundOnUrl` combinations.

This change modifies the index of the found URLs arrays, by including the `foundOnUrl` value. This causes a page to be unique based on where it was found, thus showing up in a case like the one above. The crawler output for `/page3` would now be:

```
CrawledUrl {
  +crawledUrl: "http://localhost:9000/page3"
  +statusCode: 200
  +foundOnUrl: "http://localhost:9000/page1"
}

CrawledUrl {
  +crawledUrl: "http://localhost:9000/page3"
  +statusCode: 200
  +foundOnUrl: "http://localhost:9000/page2"
}
```

Showing every page that particular URL was found on.

Even though all previous tests pass, this is probably a breaking change. It will start to report more pages in the output.