### PR TITLE
WIP: add new observer method that is called when a link is found *again*

### DIFF
--- a/src/CrawlObserver.php
+++ b/src/CrawlObserver.php
@@ -31,7 +31,7 @@ abstract class CrawlObserver
     );
 
     /**
-     * Called when the crawler has found the url again
+     * Called when the crawler has found the url again.
      *
      * @param \Psr\Http\Message\UriInterface $url
      * @param \Psr\Http\Message\ResponseInterface $response

--- a/src/CrawlObserver.php
+++ b/src/CrawlObserver.php
@@ -31,6 +31,18 @@ abstract class CrawlObserver
     );
 
     /**
+     * Called when the crawler has found the url again
+     *
+     * @param \Psr\Http\Message\UriInterface $url
+     * @param \Psr\Http\Message\ResponseInterface $response
+     * @param \Psr\Http\Message\UriInterface|null $foundOnUrl
+     */
+    abstract public function alreadyCrawled(
+        UriInterface $url,
+        ?UriInterface $foundOnUrl = null
+    );
+
+    /**
      * Called when the crawler had a problem crawling the given url.
      *
      * @param \Psr\Http\Message\UriInterface $url

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -484,8 +484,9 @@ class Crawler
 
         if ($this->getCrawlQueue()->has($crawlUrl->url)) {
             foreach ($this->crawlObservers as $crawlObserver) {
-                $crawlObserver->alreadyCrawled($crawlUrl->url,$crawlUrl->foundOnUrl);
+                $crawlObserver->alreadyCrawled($crawlUrl->url, $crawlUrl->foundOnUrl);
             }
+
             return $this;
         }
 

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -483,6 +483,9 @@ class Crawler
         }
 
         if ($this->getCrawlQueue()->has($crawlUrl->url)) {
+            foreach ($this->crawlObservers as $crawlObserver) {
+                $crawlObserver->alreadyCrawled($crawlUrl->url,$crawlUrl->foundOnUrl);
+            }
             return $this;
         }
 


### PR DESCRIPTION
I have found I needed to add this to allow my `CrawlObserver` to count the number of times a link is found, and also collate all the `foundOnUrl`'s for the given link.

I can now report *all* pages that link to a specific 404 rather than just the first one it was found on.

If this was already possible please let me know, I couldn't find another way :)

I can add tests and docs if you'd be interested in merging?

I guess adding new abstract function would break BC on all existing observer implementations, this would need to be major release?