### PR TITLE
Bugfix: respect maximum response size when checking Robots Meta tags

### DIFF
--- a/src/CrawlerRobots.php
+++ b/src/CrawlerRobots.php
@@ -17,11 +17,11 @@ class CrawlerRobots
     /** @var bool */
     protected $mustRespectRobots;
 
-    public function __construct(ResponseInterface $response, bool $mustRespectRobots)
+    public function __construct(array $headers, string $body, bool $mustRespectRobots)
     {
-        $this->robotsHeaders = RobotsHeaders::create($response->getHeaders());
+        $this->robotsHeaders = RobotsHeaders::create($headers);
 
-        $this->robotsMeta = RobotsMeta::create((string) $response->getBody());
+        $this->robotsMeta = RobotsMeta::create($body);
 
         $this->mustRespectRobots = $mustRespectRobots;
     }

--- a/src/CrawlerRobots.php
+++ b/src/CrawlerRobots.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\Crawler;
 
-use Psr\Http\Message\ResponseInterface;
 use Spatie\Robots\RobotsHeaders;
 use Spatie\Robots\RobotsMeta;
 

--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -31,7 +31,13 @@ class CrawlRequestFulfilled
 
     public function __invoke(ResponseInterface $response, $index)
     {
-        $robots = new CrawlerRobots($response, $this->crawler->mustRespectRobots());
+        $body = $this->convertBodyToString($response->getBody(), $this->crawler->getMaximumResponseSize());
+
+        $robots = new CrawlerRobots(
+            $response->getHeaders(),
+            $body,
+            $this->crawler->mustRespectRobots()
+        );
 
         $crawlUrl = $this->crawler->getCrawlQueue()->getUrlById($index);
 
@@ -55,7 +61,6 @@ class CrawlRequestFulfilled
             return;
         }
 
-        $body = $this->convertBodyToString($response->getBody(), $this->crawler->getMaximumResponseSize());
         $baseUrl = $this->getBaseUrl($response, $crawlUrl);
 
         $this->linkAdder->addFromHtml($body, $baseUrl);


### PR DESCRIPTION
Large HTML bodies would be passed as-is to the `RobotsMeta` check. If there was a 100MB HTML blob, it would be passed as a giant string to that class, causing out of memory issues further down the stack.

This (breaking) change modifies this behaviour, by respecting the maximum responze size (default: 2MB) when checking the body for HTML meta tags.

Alternate implementation would be to extract `convertBodyToString()` to a helper function, so it could be called from both `CrawlRequestFulfilled` and `CrawlerRobots`. However, it looks like `CrawlerRobots` is only used internally here, the breaking change might not actually affect anyone.