### PR TITLE
Added option to customize xpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,16 @@ This package comes with three `CrawlProfiles` out of the box:
 - `CrawlInternalUrls`: this profile will only crawl the internal urls on the pages of a host.
 - `CrawlSubdomains`: this profile will only crawl the internal urls and its subdomains on the pages of a host.
 
+By default, the xpath would be all 'a' links. Optionally, you can set an $xpath property in your extended class to filter urls by the xpath.
+```php
+/*
+ * Determines the xpath to be crawled
+ */
+public $xpath = '//html/body/section/section[*]/header/h1/a';
+```
+
+This should crawl only Posts in [https://nikic.github.io/](https://nikic.github.io/) website, not header links.
+
 ### Ignoring robots.txt and robots meta
 
 By default, the crawler will respect robots data. It is possible to disable these checks like so:

--- a/src/CrawlProfile.php
+++ b/src/CrawlProfile.php
@@ -7,6 +7,12 @@ use Psr\Http\Message\UriInterface;
 abstract class CrawlProfile
 {
     /**
+     * Determines the xpath to be crawled.
+     * @param string $xpath
+     */
+    public $xpath = '//a';
+
+    /**
      * Determine if the given url should be crawled.
      *
      * @param \Psr\Http\Message\UriInterface $url

--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -63,7 +63,7 @@ class CrawlRequestFulfilled
 
         $baseUrl = $this->getBaseUrl($response, $crawlUrl);
 
-        $this->linkAdder->addFromHtml($body, $baseUrl);
+        $this->linkAdder->addFromHtml($body, $baseUrl, $this->crawler->getCrawlProfile()->xpath);
 
         usleep($this->crawler->getDelayBetweenRequests());
     }

--- a/src/LinkAdder.php
+++ b/src/LinkAdder.php
@@ -19,9 +19,9 @@ class LinkAdder
         $this->crawler = $crawler;
     }
 
-    public function addFromHtml(string $html, UriInterface $foundOnUrl)
+    public function addFromHtml(string $html, UriInterface $foundOnUrl, string $xpath)
     {
-        $allLinks = $this->extractLinksFromHtml($html, $foundOnUrl);
+        $allLinks = $this->extractLinksFromHtml($html, $foundOnUrl, $xpath);
 
         collect($allLinks)
             ->filter(function (UriInterface $url) {
@@ -54,14 +54,15 @@ class LinkAdder
     /**
      * @param string $html
      * @param \Psr\Http\Message\UriInterface $foundOnUrl
+     * @param string $xpath
      *
      * @return \Illuminate\Support\Collection|\Tightenco\Collect\Support\Collection|null
      */
-    protected function extractLinksFromHtml(string $html, UriInterface $foundOnUrl)
+    protected function extractLinksFromHtml(string $html, UriInterface $foundOnUrl, string $xpath)
     {
         $domCrawler = new DomCrawler($html, $foundOnUrl);
 
-        return collect($domCrawler->filterXpath('//a | //link[@rel="next" or @rel="prev"]')->links())
+        return collect($domCrawler->filterXpath($xpath. ' | //link[@rel="next" or @rel="prev"]')->links())
             ->reject(function (Link $link) {
                 return $link->getNode()->getAttribute('rel') === 'nofollow';
             })

--- a/tests/CrawlerProfileTest.php
+++ b/tests/CrawlerProfileTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\Crawler\Test;
+
+use Psr\Http\Message\UriInterface;
+use Spatie\Crawler\CrawlProfile;
+
+class CrawlerProfileTest extends CrawlProfile
+{
+    public $xpath = '//html/body/a[4]';
+
+    public function shouldCrawl(UriInterface $url): bool
+    {
+        return true;
+    }
+}

--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -192,6 +192,32 @@ class CrawlerTest extends TestCase
     }
 
     /** @test */
+    public function it_uses_crawl_profile_for_xpath()
+    {
+        Crawler::create()
+            ->setCrawlObserver(new CrawlLogger())
+            ->setCrawlProfile(new CrawlerProfileTest('localhost:8080'))
+            ->startCrawling('http://localhost:8080');
+
+        $this->assertCrawledOnce([
+            ['url' => 'http://localhost:8080/link1', 'foundOn' => 'http://localhost:8080/'],
+            ['url' => 'http://localhost:8080/link1-prev', 'foundOn' => 'http://localhost:8080/link1'],
+            ['url' => 'http://localhost:8080/link1-next', 'foundOn' => 'http://localhost:8080/link1'],
+        ]);
+
+        $this->assertNotCrawled([
+            ['url' => 'http://localhost:8080/txt-disallow'],
+            ['url' => 'http://localhost:8080/meta-follow'],
+            ['url' => 'http://localhost:8080/header-disallow'],
+            ['url' => 'http://localhost:8080/link2'],
+            ['url' => 'http://localhost:8080/dir/link4'],
+            ['url' => 'http://localhost:8080/nofollow'],
+            ['url' => 'http://localhost:8080/txt-disallow-custom-user-agent'],
+        ]);
+
+    }
+
+    /** @test */
     public function it_can_handle_pages_with_invalid_urls()
     {
         $crawlProfile = new class extends CrawlProfile {


### PR DESCRIPTION
This is DPR making it able to customize the xpath value for a given Crawl.
This is just a draft, but I think it can come in handy for a lot of use cases.

It would be great if you could take a look and code review as I am not very experienced or prompt me to some direction, but I think this functionality would be of great use since it allows average crawling urls to significantly drop which can improve performance and also less requests means less bans.

CrawlProfile class should be able to distinguish pages(maybe according to depth) to provide different xpaths. This is a basic use case for example for Ecommerce crawling.
e.g. Distinguishing product pages from headert,footer,sociallinks etc in ecommerce crawling
Could work more on that.

If you could provide me some feedback it would be great