### PR TITLE
Fix LinkAdder not receiving the updated DOM

### DIFF
--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -42,9 +42,9 @@ class CrawlRequestFulfilled
         $crawlUrl = $this->crawler->getCrawlQueue()->getUrlById($index);
 
         if ($this->crawler->mayExecuteJavaScript()) {
-            $html = $this->getBodyAfterExecutingJavaScript($crawlUrl->url);
+            $body = $this->getBodyAfterExecutingJavaScript($crawlUrl->url);
 
-            $response = $response->withBody(stream_for($html));
+            $response = $response->withBody(stream_for($body));
         }
 
         if ($robots->mayIndex()) {


### PR DESCRIPTION
I'm using [spatie/laravel-sitemap](https://github.com/spatie/laravel-sitemap) for a SPA and noticed that the sitemap is no longer generated properly. It's always a single node xml with the homepage only.

After digging, I've found that the LinkAdder instance never receives the DOM after executing the JavaScript, therefore the other urls added after executing JavaScript are never crawled.