### PR TITLE
Add support for setParseableMimeTypes()

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,17 @@ Crawler::create()
     ->setDelayBetweenRequests(150) // After every page crawled, the crawler will wait for 150ms
 ```
 
+## Limiting which content-types to parse
+
+By default, every found page will be downloaded (up to `setMaximumResponseSize()` in size) and parsed for additional links. You can limit which content-types should be downloaded and parsed by setting the `setParseableMimeTypes()` with an array of allowed types.
+
+```php
+Crawler::create()
+    ->setParseableMimeTypes(['text/html', 'text/plain']) 
+```
+
+This will prevent downloading the body of pages that have different mime types, like binary files, audio/video, ... that are unlikely to have links embedded in them. This feature mostly saves bandwidth.
+
 ## Using a custom crawl queue
 
 When crawling a site the crawler will put urls to be crawled in a queue. By default, this queue is stored in memory using the built-in `CollectionCrawlQueue`.

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -76,6 +76,9 @@ class Crawler
     /** @var int */
     protected $delayBetweenRequests = 0;
 
+    /** @var array */
+    protected $allowedMimeTypes = [];
+
     /** @var   */
     protected static $defaultClientOptions = [
         RequestOptions::COOKIES => true,
@@ -182,6 +185,27 @@ class Crawler
     {
         return $this->delayBetweenRequests;
     }
+
+    /**
+     * @param array $types The allowed mimetypes to parse
+     *
+     * @return Crawler
+     */
+    public function setParseableMimeTypes(array $types): Crawler
+    {
+        $this->allowedMimeTypes = $types;
+
+        return $this;
+    }
+
+    /**
+     * @return int The allowed mimetypes to prase
+     */
+    public function getParseableMimeTypes(): array
+    {
+        return $this->allowedMimeTypes;
+    }
+
 
     public function ignoreRobots(): Crawler
     {

--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -437,4 +437,33 @@ class CrawlerTest extends TestCase
 
         $this->assertSame($newUserAgent, $actualUserAgent);
     }
+
+    /** @test */
+    public function it_will_only_crawl_correct_mime_types_when_asked_to()
+    {
+        Crawler::create()
+            ->setCrawlObserver(new CrawlLogger())
+            ->setParseableMimeTypes(['text/html', 'text/plain'])
+            ->startCrawling('http://localhost:8080/content-types');
+
+        $this->assertNotCrawled([['url' => 'http://localhost:8080/content-types/music.html', 'foundOn' => 'http://localhost:8080/content-types/music.mp3']]);
+        $this->assertNotCrawled([['url' => 'http://localhost:8080/content-types/video.html', 'foundOn' => 'http://localhost:8080/content-types/video.mkv']]);
+
+        $this->assertCrawledOnce([['url' => 'http://localhost:8080/content-types/normal.html', 'foundOn' => 'http://localhost:8080/content-types']]);
+
+        $this->assertCrawledUrlCount(4);
+    }
+
+    /** @test */
+    public function it_will_crawl_all_content_types_when_not_explicitly_whitelisted()
+    {
+        Crawler::create()
+            ->setCrawlObserver(new CrawlLogger())
+            ->startCrawling('http://localhost:8080/content-types');
+
+        $this->assertCrawledOnce([['url' => 'http://localhost:8080/content-types/music.html', 'foundOn' => 'http://localhost:8080/content-types/music.mp3']]);
+        $this->assertCrawledOnce([['url' => 'http://localhost:8080/content-types/video.html', 'foundOn' => 'http://localhost:8080/content-types/video.mkv']]);
+
+        $this->assertCrawledUrlCount(6);
+    }
 }

--- a/tests/server/server.js
+++ b/tests/server/server.js
@@ -88,6 +88,36 @@ app.get('/header-disallow', function (request, response) {
     response.end('disallow by header');
 });
 
+app.get('/content-types', function (request, response) {
+    response.end('We have <a href="/content-types/normal.html">a normal page</a>, <a href="/content-types/music.mp3">an MP3</a> and <a href="/content-types/video.mkv">a video file</a>.');
+});
+
+app.get('/content-types/normal.html', function (request, response) {
+    response.set({'Content-Type': 'text/html; charset=utf-8'});
+
+    response.end('a normal HTML file');
+});
+
+app.get('/content-types/music.mp3', function (request, response) {
+    response.set({'Content-Type': 'audio/mpeg'});
+
+    response.end('music file, with a <a href="/content-types/music.html">a link</a>');
+});
+
+app.get('/content-types/music.html', function (request, response) {
+    response.end('hidden html in music file');
+});
+
+app.get('/content-types/video.mkv', function (request, response) {
+    response.set({'Content-Type': 'video/webm'});
+
+    response.end('video file, with a <a href="/content-types/video.html">a link</a>');
+});
+
+app.get('/content-types/video.html', function (request, response) {
+    response.end('hidden html in video file');
+});
+
 app.get('/robots.txt', function (req, res) {
     var html = 'User-agent: *\n' +
         'Disallow: /txt-disallow\n' +


### PR DESCRIPTION
By default, every found page will be downloaded (up to `setMaximumResponseSize()` in size) and parsed for additional links. You can limit which content-types should be downloaded and parsed by setting the `setParseableMimeTypes()` with an array of allowed types.

```php
Crawler::create()
    ->setParseableMimeTypes(['text/html', 'text/plain'])
```

This will prevent downloading the body of pages that have different mime types, like binary files, audio/video, ... that are unlikely to have links embedded in them. This feature mostly saves bandwidth.