### PR TITLE
Improvement: pass the body to each crawled() implementation

### DIFF
--- a/src/CrawlObserver.php
+++ b/src/CrawlObserver.php
@@ -27,7 +27,8 @@ abstract class CrawlObserver
     abstract public function crawled(
         UriInterface $url,
         ResponseInterface $response,
-        ?UriInterface $foundOnUrl = null
+        ?UriInterface $foundOnUrl = null,
+        string $body = ""
     );
 
     /**
@@ -40,7 +41,8 @@ abstract class CrawlObserver
     abstract public function crawlFailed(
         UriInterface $url,
         RequestException $requestException,
-        ?UriInterface $foundOnUrl = null
+        ?UriInterface $foundOnUrl = null,
+        string $body = ""
     );
 
     /**

--- a/src/CrawlObserverCollection.php
+++ b/src/CrawlObserverCollection.php
@@ -27,24 +27,26 @@ class CrawlObserverCollection implements ArrayAccess, Iterator
         $this->observers[] = $observer;
     }
 
-    public function crawled(CrawlUrl $crawlUrl, ResponseInterface $response)
+    public function crawled(CrawlUrl $crawlUrl, ResponseInterface $response, string $body = "")
     {
         foreach ($this->observers as $crawlObserver) {
             $crawlObserver->crawled(
                 $crawlUrl->url,
                 $response,
-                $crawlUrl->foundOnUrl
+                $crawlUrl->foundOnUrl,
+                $body
             );
         }
     }
 
-    public function crawlFailed(CrawlUrl $crawlUrl, RequestException $exception)
+    public function crawlFailed(CrawlUrl $crawlUrl, RequestException $exception, string $body = "")
     {
         foreach ($this->observers as $crawlObserver) {
             $crawlObserver->crawlFailed(
                 $crawlUrl->url,
                 $exception,
-                $crawlUrl->foundOnUrl
+                $crawlUrl->foundOnUrl,
+                $body
             );
         }
     }

--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -48,7 +48,7 @@ class CrawlRequestFulfilled
         }
 
         if ($robots->mayIndex()) {
-            $this->handleCrawled($response, $crawlUrl);
+            $this->handleCrawled($response, $crawlUrl, $body);
         }
 
         if (! $this->crawler->getCrawlProfile() instanceof CrawlSubdomains) {
@@ -79,9 +79,9 @@ class CrawlRequestFulfilled
         return new Uri(end($redirectHistory));
     }
 
-    protected function handleCrawled(ResponseInterface $response, CrawlUrl $crawlUrl)
+    protected function handleCrawled(ResponseInterface $response, CrawlUrl $crawlUrl, string $body)
     {
-        $this->crawler->getCrawlObservers()->crawled($crawlUrl, $response);
+        $this->crawler->getCrawlObservers()->crawled($crawlUrl, $response, $body);
     }
 
     protected function convertBodyToString(StreamInterface $bodyStream, $readMaximumBytes = 1024 * 1024 * 2): string

--- a/tests/CrawlLogger.php
+++ b/tests/CrawlLogger.php
@@ -41,7 +41,8 @@ class CrawlLogger extends CrawlObserver
     public function crawled(
         UriInterface $url,
         ResponseInterface $response,
-        ?UriInterface $foundOnUrl = null
+        ?UriInterface $foundOnUrl = null,
+        string $body = ""
     ) {
         $this->logCrawl($url, $foundOnUrl);
     }
@@ -49,7 +50,8 @@ class CrawlLogger extends CrawlObserver
     public function crawlFailed(
         UriInterface $url,
         RequestException $requestException,
-        ?UriInterface $foundOnUrl = null
+        ?UriInterface $foundOnUrl = null,
+        string $body = ""
     ) {
         $this->logCrawl($url, $foundOnUrl);
     }

--- a/tests/CrawlObserverCollectionTest.php
+++ b/tests/CrawlObserverCollectionTest.php
@@ -29,7 +29,8 @@ class CrawlObserverCollectionTest extends TestCase
             public function crawled(
                 UriInterface $url,
                 ResponseInterface $response,
-                ?UriInterface $foundOnUrl = null
+                ?UriInterface $foundOnUrl = null,
+                string $body = ""
             ) {
                 $this->crawled = true;
             }
@@ -37,7 +38,8 @@ class CrawlObserverCollectionTest extends TestCase
             public function crawlFailed(
                 UriInterface $url,
                 RequestException $requestException,
-                ?UriInterface $foundOnUrl = null
+                ?UriInterface $foundOnUrl = null,
+                string $body = ""
             ) {
                 $this->failed = true;
             }


### PR DESCRIPTION
Problem: if you use a Crawler Client with Curls' streaming implementation, the body can only be read once.

Ie:

```
$clientConfig = ['stream' => true];

Crawler::create($clientConfig)
            ->setCrawlObserver(new CrawlLogger())
            ->startCrawling('https://site.tld');
```

Each crawled page will have a `$response` object with a `getBody()` method. But since it's using PHP's streams, the body can only be read once.

If you have multiple observers, only the first observer will have access to the body.

This PR adds the ability to pass the body to each observer, ensuring every observer has access to the full body as limited by `setMaximumResponseSize()` and `setParseableMimeTypes()`.

Downside: this is a breaking change, as it changes the signatures of the `crawled()` implementations.