### PR TITLE
Link Adder; only add links that can be completely parsed

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ By default, every found page will be downloaded (up to `setMaximumResponseSize()
 
 ```php
 Crawler::create()
-    ->setParseableMimeTypes(['text/html', 'text/plain']) 
+    ->setParseableMimeTypes(['text/html', 'text/plain'])
 ```
 
 This will prevent downloading the body of pages that have different mime types, like binary files, audio/video, ... that are unlikely to have links embedded in them. This feature mostly saves bandwidth.
@@ -263,7 +263,7 @@ Crawler::create()
     ->setCrawlQueue(<implementation of \Spatie\Crawler\CrawlQueue\CrawlQueue>)
 ```
 
-Here 
+Here
 
 - [ArrayCrawlQueue](https://github.com/spatie/crawler/blob/master/src/CrawlQueue/ArrayCrawlQueue.php)
 - [CollectionCrawlQueue](https://github.com/spatie/crawler/blob/master/src/CrawlQueue/CollectionCrawlQueue.php) (`Illuminate\Support\Collection` or `Tightenco\Collect\Support\Collection`)
@@ -279,12 +279,18 @@ Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 ## Testing
 
+First, install the Puppeteer dependency, or your tests will fail.
+
+```
+npm install puppeteer
+```
+
 To run the tests you'll have to start the included node based server first in a separate terminal window.
 
 ```bash
 cd tests/server
 npm install
-./start_server.sh
+node server.js
 ```
 
 With the server running, you can start testing.

--- a/src/LinkAdder.php
+++ b/src/LinkAdder.php
@@ -63,7 +63,16 @@ class LinkAdder
 
         return collect($domCrawler->filterXpath('//a | //link[@rel="next" or @rel="prev"]')->links())
             ->reject(function (Link $link) {
-                return $link->getNode()->getAttribute('rel') === 'nofollow';
+                // Validate <a href> to make sure they are valid
+                if ($this->isInvalidHrefNode($link)) {
+                    return true;
+                }
+
+                if ($link->getNode()->getAttribute('rel') === 'nofollow') {
+                    return true;
+                }
+
+                return false;
             })
             ->map(function (Link $link) {
                 try {
@@ -98,5 +107,14 @@ class LinkAdder
         }
 
         return $node->getDepth() <= $maximumDepth;
+    }
+
+    private function isInvalidHrefNode(Link $link): bool
+    {
+        if ($link->getNode()->nodeName == "a") {
+            return $link->getNode()->nextSibling === null && $link->getNode()->childNodes->length == 0;
+        }
+
+        return false;
     }
 }

--- a/src/LinkAdder.php
+++ b/src/LinkAdder.php
@@ -63,7 +63,6 @@ class LinkAdder
 
         return collect($domCrawler->filterXpath('//a | //link[@rel="next" or @rel="prev"]')->links())
             ->reject(function (Link $link) {
-                // Validate <a href> to make sure they are valid
                 if ($this->isInvalidHrefNode($link)) {
                     return true;
                 }

--- a/src/LinkAdder.php
+++ b/src/LinkAdder.php
@@ -95,7 +95,6 @@ class LinkAdder
 
     protected function shouldCrawl(Node $node): bool
     {
-        
         if ($this->crawler->mustRespectRobots() && ! $this->crawler->getRobotsTxt()->allows($node->getValue(), $this->crawler->getUserAgent())) {
             return false;
         }
@@ -114,7 +113,7 @@ class LinkAdder
         if ($link->getNode()->nodeName !== 'a') {
             return false;
         }
-        
+
         if ($link->getNode()->nextSibling !== null) {
             return false;
         }

--- a/src/LinkAdder.php
+++ b/src/LinkAdder.php
@@ -95,6 +95,7 @@ class LinkAdder
 
     protected function shouldCrawl(Node $node): bool
     {
+        
         if ($this->crawler->mustRespectRobots() && ! $this->crawler->getRobotsTxt()->allows($node->getValue(), $this->crawler->getUserAgent())) {
             return false;
         }
@@ -110,10 +111,18 @@ class LinkAdder
 
     private function isInvalidHrefNode(Link $link): bool
     {
-        if ($link->getNode()->nodeName == 'a') {
-            return $link->getNode()->nextSibling === null && $link->getNode()->childNodes->length == 0;
+        if ($link->getNode()->nodeName !== 'a') {
+            return false;
+        }
+        
+        if ($link->getNode()->nextSibling !== null) {
+            return false;
         }
 
-        return false;
+        if ($link->getNode()->childNodes->length !== 0) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/LinkAdder.php
+++ b/src/LinkAdder.php
@@ -108,7 +108,7 @@ class LinkAdder
         return $node->getDepth() <= $maximumDepth;
     }
 
-    private function isInvalidHrefNode(Link $link): bool
+    protected function isInvalidHrefNode(Link $link): bool
     {
         if ($link->getNode()->nodeName !== 'a') {
             return false;

--- a/src/LinkAdder.php
+++ b/src/LinkAdder.php
@@ -111,7 +111,7 @@ class LinkAdder
 
     private function isInvalidHrefNode(Link $link): bool
     {
-        if ($link->getNode()->nodeName == "a") {
+        if ($link->getNode()->nodeName == 'a') {
             return $link->getNode()->nextSibling === null && $link->getNode()->childNodes->length == 0;
         }
 

--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -481,4 +481,16 @@ class CrawlerTest extends TestCase
 
         $this->assertCrawledUrlCount(6);
     }
+
+    /** @test */
+    public function it_will_not_crawl_half_parsed_href_tags()
+    {
+        Crawler::create()
+            ->setCrawlObserver(new CrawlLogger())
+            ->startCrawling('http://localhost:8080/incomplete-href');
+
+        $this->assertNotCrawled([['url' => 'http://localhost:8080/invalid-link', 'foundOn' => 'http://localhost:8080/incomplete-href']]);
+
+        $this->assertCrawledUrlCount(3);
+    }
 }

--- a/tests/server/server.js
+++ b/tests/server/server.js
@@ -118,6 +118,10 @@ app.get('/content-types/video.html', function (request, response) {
     response.end('hidden html in video file');
 });
 
+app.get('/incomplete-href', function (request, response) {
+    response.end('Valid href: <a href="/link1-next">valid link</a>, Empty href: <a href="/link1-prev"></a>, Incomplete href: <a href="/invalid-link');
+});
+
 app.get('/robots.txt', function (req, res) {
     var html = 'User-agent: *\n' +
         'Disallow: /txt-disallow\n' +


### PR DESCRIPTION
Situation: now that there is an ability to only parse the first X bytes of a page, it's possible that there is a link that gets parsed that isn't entirely valid.

Take this configuration:

```
Crawler::create()
    ->setMaximumResponseSize(1024 * 512)
```

This will parse the first 512KB of a page. This means the body that the crawler is working with, might contain something like this:

```
<HTML>
...
<ul>
  <li> <a href="/link1">link #1</a> </li>
  <li> <a href="/link2">link #2</a> </li>
  <li> <a href="/li
```

That third item should obviously point to `/link3`, but since we cut the dom at 512KB, it might not be complete there.

This PR prevents the parsing of that last link, by checking if there is;
1. A HTML element _after_ the link that is being parsed
2. The found HTML element contains at least 1 child node (the text between <a></a>)

The Symfony DOMCrawler accepts non-fully closed `href` tags as valid, which causes weird situations if the HTML DOM is only partially parsed.