### PR TITLE
BodyStream: read the data in chunks

### DIFF
--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -90,7 +90,7 @@ class CrawlRequestFulfilled
             $bodyStream->rewind();
         }
 
-        $body = "";
+        $body = '';
 
         $chunksToRead = $readMaximumBytes < 512 ? $readMaximumBytes : 512;
 

--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -90,7 +90,19 @@ class CrawlRequestFulfilled
             $bodyStream->rewind();
         }
 
-        $body = $bodyStream->read($readMaximumBytes);
+        $body = "";
+
+        $chunksToRead = $readMaximumBytes < 512 ? $readMaximumBytes : 512;
+
+        for ($bytesRead = 0; $bytesRead < $readMaximumBytes; $bytesRead += $chunksToRead) {
+            $newDataRead = $bodyStream->read($chunksToRead);
+
+            if (! $newDataRead) {
+                break;
+            }
+
+            $body .= $newDataRead;
+        }
 
         return $body;
     }

--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -95,7 +95,11 @@ class CrawlRequestFulfilled
         $chunksToRead = $readMaximumBytes < 512 ? $readMaximumBytes : 512;
 
         for ($bytesRead = 0; $bytesRead < $readMaximumBytes; $bytesRead += $chunksToRead) {
-            $newDataRead = $bodyStream->read($chunksToRead);
+            try {
+                $newDataRead = $bodyStream->read($chunksToRead);
+            } catch (Exception $e) {
+                $newDataRead = null;
+            }
 
             if (! $newDataRead) {
                 break;


### PR DESCRIPTION
Bug: not every stream allows all requested data for the page body to be read in a single go.

This PR resolves this by loading data in chunks of 512 bytes, until the maximum of `$readMaximumBytes` is reached.

Functionally, this doesn't change anything to the parser, it just loads the HTML body more efficiently.

I failed to come up with a good test for this in nodejs, as it appears to be a very low-level implementation issue that causes streams to only accept small chunks of data. The error occurs on data hosted at Google's Storage API's.