### PR TITLE
Bugfix: import the correct Exception namespace

### DIFF
--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -90,7 +90,7 @@ class CrawlRequestFulfilled
             $bodyStream->rewind();
         }
 
-        $body = "";
+        $body = '';
 
         $chunksToRead = $readMaximumBytes < 512 ? $readMaximumBytes : 512;
 

--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -90,7 +90,19 @@ class CrawlRequestFulfilled
             $bodyStream->rewind();
         }
 
-        $body = $bodyStream->read($readMaximumBytes);
+        $body = "";
+
+        $chunksToRead = $readMaximumBytes < 512 ? $readMaximumBytes : 512;
+
+        for ($bytesRead = 0; $bytesRead < $readMaximumBytes; $bytesRead += $chunksToRead) {
+            $newDataRead = $bodyStream->read($chunksToRead);
+
+            if (! $newDataRead) {
+                break;
+            }
+
+            $body .= $newDataRead;
+        }
 
         return $body;
     }

--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -95,7 +95,11 @@ class CrawlRequestFulfilled
         $chunksToRead = $readMaximumBytes < 512 ? $readMaximumBytes : 512;
 
         for ($bytesRead = 0; $bytesRead < $readMaximumBytes; $bytesRead += $chunksToRead) {
-            $newDataRead = $bodyStream->read($chunksToRead);
+            try {
+                $newDataRead = $bodyStream->read($chunksToRead);
+            } catch (Exception $e) {
+                $newDataRead = null;
+            }
 
             if (! $newDataRead) {
                 break;

--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Crawler\Handlers;
 
+use Exception;
 use function GuzzleHttp\Psr7\stream_for;
 use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\RedirectMiddleware;


### PR DESCRIPTION
Subtle bug: the `Exception` wasn't being caught as it wasn't imported.