### PR TITLE
Add crawler option to allow crawl links with rel="nofollow"

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,16 @@ More information on the spec can be found here: [http://www.robotstxt.org/](http
 
 Parsing robots data is done by our package [spatie/robots-txt](https://github.com/spatie/robots-txt).
 
+### Accept links with rel="nofollow" attribute
+
+By default, the crawler will reject all links containing attribute rel="nofollow". It is possible to disable these checks like so:
+
+```php
+Crawler::create()
+    ->acceptNofollowLinks()
+    ...
+```
+
 ### Using a custom User Agent ###
 
 In order to respect robots.txt rules for a custom User Agent you can specify your own custom User Agent.

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -55,6 +55,9 @@ class Crawler
     /** @var bool */
     protected $respectRobots = true;
 
+    /** @var bool */
+    protected $rejectNofollowLinks = true;
+
     /** @var \Tree\Node\Node */
     protected $depthTree;
 
@@ -223,6 +226,25 @@ class Crawler
     public function mustRespectRobots(): bool
     {
         return $this->respectRobots;
+    }
+
+    public function acceptNofollowLinks(): Crawler
+    {
+        $this->rejectNofollowLinks = false;
+
+        return $this;
+    }
+
+    public function rejectNofollowLinks(): Crawler
+    {
+        $this->rejectNofollowLinks = true;
+
+        return $this;
+    }
+
+    public function mustRespectNofollowLinks(): bool
+    {
+        return $this->respectNofollowLinks;
     }
 
     public function getRobotsTxt(): RobotsTxt

--- a/src/LinkAdder.php
+++ b/src/LinkAdder.php
@@ -67,7 +67,7 @@ class LinkAdder
                     return true;
                 }
 
-                if ($link->getNode()->getAttribute('rel') === 'nofollow') {
+                if ($this->crawler->mustRejectNofollowLinks() && $link->getNode()->getAttribute('rel') === 'nofollow') {
                     return true;
                 }
 


### PR DESCRIPTION
Sometimes it may be necessary to get links containing the attribute rel="nofollow". 
I think it should be possible to allow the collection of such links.