### PR TITLE
Fixing namespace in README and reference to CollectionCrawlQueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,11 +268,11 @@ This will prevent downloading the body of pages that have different mime types, 
 
 ## Using a custom crawl queue
 
-When crawling a site the crawler will put urls to be crawled in a queue. By default, this queue is stored in memory using the built-in `CollectionCrawlQueue`.
+When crawling a site the crawler will put urls to be crawled in a queue. By default, this queue is stored in memory using the built-in `ArrayCrawlQueue`.
 
 When a site is very large you may want to store that queue elsewhere, maybe a database. In such cases, you can write your own crawl queue.
 
-A valid crawl queue is any class that implements the `Spatie\Crawler\CrawlQueue\CrawlQueue`-interface. You can pass your custom crawl queue via the `setCrawlQueue` method on the crawler.
+A valid crawl queue is any class that implements the `Spatie\Crawler\CrawlQueues\CrawlQueue`-interface. You can pass your custom crawl queue via the `setCrawlQueue` method on the crawler.
 
 ```php
 Crawler::create()

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ A valid crawl queue is any class that implements the `Spatie\Crawler\CrawlQueues
 
 ```php
 Crawler::create()
-    ->setCrawlQueue(<implementation of \Spatie\Crawler\CrawlQueue\CrawlQueue>)
+    ->setCrawlQueue(<implementation of \Spatie\Crawler\CrawlQueues\CrawlQueue>)
 ```
 
 Here


### PR DESCRIPTION
Hey @freekmurze 

just fixing some details in the README (namespace and reference to `CollectionCrawlQueue`).

Cheers,
Peter