### PR TITLE
Allow for chunked crawls by not running the queue empty (fixes #325)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ abstract class CrawlObserver
     /**
      * Called when the crawl has ended.
      */
-    public function finishedCrawling() {
+    public function finishedCrawling()
+    {
 
     }
 }
@@ -130,7 +131,7 @@ Crawler::create()
 
 In order to make it possible to get the body html after the javascript has been executed, this package depends on
 our [Browsershot](https://github.com/spatie/browsershot) package.
-This package uses [Puppeteer](https://github.com/GoogleChrome/puppeteer) under the hood. Here are some pointers on [how to install it on your system](https://github.com/spatie/browsershot#requirements).
+This package uses [Puppeteer](https://github.com/puppeteer/puppeteer) under the hood. Here are some pointers on [how to install it on your system](https://github.com/spatie/browsershot#requirements).
 
 Browsershot will make an educated guess as to where its dependencies are installed on your system.
 By default, the Crawler will instantiate a new Browsershot instance. You may find the need to set a custom created instance using the `setBrowsershot(Browsershot $browsershot)` method.
@@ -220,7 +221,6 @@ By default, the crawler continues until it has crawled every page of the supplie
 
 ```php
 // stop crawling after 5 urls
-
 Crawler::create()
     ->setMaximumCrawlCount(5)
 ```

--- a/README.md
+++ b/README.md
@@ -222,13 +222,13 @@ By default, the crawler continues until it has crawled every page of the supplie
 The crawl behavior can be controlled with the following two options:
 
  - **Total Crawl Limit** (`setTotalCrawlLimit`): This limit defines the maximal count of URLs to crawl during all executions of the crawler.
- - **Current Crawl Limit** (`setCurrentCrawlLimit`): This defines how many URLs are processed during the current crawl. This allows for chunked crawls assuming you are using the same queue-instance.
+ - **Current Crawl Limit** (`setCurrentCrawlLimit`): This defines how many URLs are processed during the current crawl.
 
 The following examples demonstrate the usage further. All examples assume a website with a sufficient number of pages to crawl.
 
 ### Example 1: Using Total Crawl Limit
 
-This allows to limit the total number of URLs to crawl.
+This allows to limit the total number of URLs to crawl, however often you call the crawler.
 
 ```php
 $queue = <your selection/implementation of a queue>;
@@ -248,7 +248,7 @@ Crawler::create()
 
 ### Example 2: Using Current Crawl Limit
 
-This crawler would process 5 pages with each execution. This builds the base for chunked crawling.
+This crawler processes 5 pages with each execution, without a total limit of pages to crawl.
 
 ```php
 $queue = <your selection/implementation of a queue>;
@@ -268,7 +268,7 @@ Crawler::create()
 
 ### Example 3: Using Current & Total Crawl Limits
 
-Both limits combined can be used to crawl in chunks and limit the maximal crawling at the same time:
+Both limits can be combined to control the crawler:
 
 ```php
 $queue = <your selection/implementation of a queue>;

--- a/README.md
+++ b/README.md
@@ -295,7 +295,49 @@ Crawler::create()
     ->startCrawling($url);
 ```
 
+### Example 4: Crawling across requests
+
+Using the `CurrentCrawlLimit` allows you to crawl across different requests. The following example demonstrates the approach in the simplest variation. It's broken down in the initial request and following requests:
+
+#### Initial Request
+
+To start crawling across different requests, you will need to create a new queue of your selected queue-driver. Start by passing the queue-instance to the crawler. The crawler will start filling the queue as sites are processed and new URLs are discovered. Serialize and store the queue reference after the crawler has finished the current crawl limit.
+
+```php
+// Create a queue using your queue-driver.
+$queue = <your selection/implementation of a queue>;
+
+// Crawl the first set of URLs
+Crawler::create()
+    ->setCrawlQueue($queue)
+    ->setCurrentCrawlLimit(10)
+    ->startCrawling($url);
+
+// Serialize and store your queue
+$serialized_queue = serialize($queue);
+```
+
+#### Follow Requests
+
+For any following requests you will need to unserialize your original queue and pass it to the Crawler:
+
+```php
+// Unserialize queue
+$queue = unserialize($serialized_queue);
+
+// Crawls the next set of URLs
+Crawler::create()
+    ->setCrawlQueue($queue)
+    ->setCurrentCrawlLimit(10)
+    ->startCrawling($url);
+
+// Serialize and store your queue
+$serialized_queue = serialize($queue);
+```
+
 Note: The behavior is based on the information in the queue. Only if the same queue-instance is passed in the behavior works as described. When a completely new queue is passed in the limits of previous crawls, even for the same website, won't apply.
+
+An example with more details can be found [here](https://github.com/spekulatius/spatie-crawler-cached-queue-example). You can also download it and run it locally.
 
 
 ## Setting the maximum crawl depth
@@ -355,7 +397,8 @@ Crawler::create()
 Here
 
 - [ArrayCrawlQueue](https://github.com/spatie/crawler/blob/master/src/CrawlQueues/ArrayCrawlQueue.php)
-- [RedisCrawlQueue (third party package)](https://github.com/repat/spatie-crawler-redis)
+- [RedisCrawlQueue (third-party package)](https://github.com/repat/spatie-crawler-redis)
+- [CacheCrawlQueue for Laravel (third-party package)](https://github.com/spekulatius/spatie-crawler-toolkit-for-laravel)
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -217,14 +217,14 @@ Crawler::create()
 
 ## Defining Crawl Limits
 
-By default, the crawler continues until it has crawled every page of the supplied URL. This behavior might cause issues if you are working in an environment with limitations such as a serverless environment (e.g. AWS Lambda).
+By default, the crawler continues until it has crawled every page in scope. This behavior might cause issues if you are working in an environment with limitations such as a serverless environment (e.g. AWS Lambda).
 
 The crawl behavior can be controlled with the following two options:
 
- - **Total Crawl Limit** (`setTotalCrawlLimit`): This limit defines the maximal count of URLs to crawl during all executions of the crawler.
+ - **Total Crawl Limit** (`setTotalCrawlLimit`): This limit defines the maximal count of URLs to crawl.
  - **Current Crawl Limit** (`setCurrentCrawlLimit`): This defines how many URLs are processed during the current crawl.
 
-The following examples demonstrate the usage further. All examples assume a website with a sufficient number of pages to crawl.
+The following examples demonstrate the usage of these limits further. All examples assume a website with a sufficient number of pages to crawl.
 
 ### Example 1: Using Total Crawl Limit
 
@@ -297,11 +297,11 @@ Crawler::create()
 
 ### Example 4: Crawling across requests
 
-Using the `CurrentCrawlLimit` allows you to crawl across different requests. The following example demonstrates the approach in the simplest variation. It's broken down in the initial request and following requests:
+With the `CurrentCrawlLimit`, you can crawl across different requests and break long running crawls up. The following example demonstrates the (simplified) approach. It's made up of an initial request and any number of follow-up requests continuing the crawl:
 
 #### Initial Request
 
-To start crawling across different requests, you will need to create a new queue of your selected queue-driver. Start by passing the queue-instance to the crawler. The crawler will start filling the queue as sites are processed and new URLs are discovered. Serialize and store the queue reference after the crawler has finished the current crawl limit.
+To start crawling across different requests, you will need to create a new queue of your selected queue-driver. Start by passing the queue-instance to the crawler. The crawler will start filling the queue as pages are processed and new URLs are discovered. Serialize and store the queue reference after the crawler has finished (using the current crawl limit).
 
 ```php
 // Create a queue using your queue-driver.
@@ -335,7 +335,7 @@ Crawler::create()
 $serialized_queue = serialize($queue);
 ```
 
-Note: The behavior is based on the information in the queue. Only if the same queue-instance is passed in the behavior works as described. When a completely new queue is passed in the limits of previous crawls, even for the same website, won't apply.
+*Note:* The behavior is based on the information in the queue. Only if the same queue-instance is passed in the behavior works as described. When a completely new queue is passed in, the limits of previous crawls -even for the same website- won't apply.
 
 An example with more details can be found [here](https://github.com/spekulatius/spatie-crawler-cached-queue-example). You can also download it and run it locally.
 

--- a/src/CrawlQueues/ArrayCrawlQueue.php
+++ b/src/CrawlQueues/ArrayCrawlQueue.php
@@ -73,6 +73,11 @@ class ArrayCrawlQueue implements CrawlQueue
         unset($this->pendingUrls[$urlString]);
     }
 
+    public function getProcessedUrlCount(): int
+    {
+        return count($this->urls) - count($this->pendingUrls);
+    }
+
     /**
      * @param CrawlUrl|UriInterface $crawlUrl
      *

--- a/src/CrawlQueues/ArrayCrawlQueue.php
+++ b/src/CrawlQueues/ArrayCrawlQueue.php
@@ -96,7 +96,7 @@ class ArrayCrawlQueue implements CrawlQueue
         return isset($this->urls[$urlString]);
     }
 
-    public function getFirstPendingUrl(): ?CrawlUrl
+    public function getPendingUrl(): ?CrawlUrl
     {
         foreach ($this->pendingUrls as $pendingUrl) {
             return $pendingUrl;

--- a/src/CrawlQueues/CrawlQueue.php
+++ b/src/CrawlQueues/CrawlQueue.php
@@ -19,4 +19,6 @@ interface CrawlQueue
     public function hasAlreadyBeenProcessed(CrawlUrl $url): bool;
 
     public function markAsProcessed(CrawlUrl $crawlUrl): void;
+
+    public function getProcessedUrlCount(): int;
 }

--- a/src/CrawlQueues/CrawlQueue.php
+++ b/src/CrawlQueues/CrawlQueue.php
@@ -14,7 +14,7 @@ interface CrawlQueue
 
     public function getUrlById($id): CrawlUrl;
 
-    public function getFirstPendingUrl(): ?CrawlUrl;
+    public function getPendingUrl(): ?CrawlUrl;
 
     public function hasAlreadyBeenProcessed(CrawlUrl $url): bool;
 

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -526,13 +526,15 @@ class Crawler
     public function reachedCrawlLimits(): bool
     {
         $totalCrawlLimit = $this->getTotalCrawlLimit();
-        $currentCrawlLimit = $this->getCurrentCrawlLimit();
+        if (!is_null($totalCrawlLimit) && $this->getTotalCrawlCount() >= $totalCrawlLimit) {
+            return true;
+        }
 
-        return (
-            is_null($totalCrawlLimit) ||
-            !is_null($totalCrawlLimit) && $this->getTotalCrawlCount() >= $totalCrawlLimit ||
-            is_null($currentCrawlLimit) ||
-            !is_null($currentCrawlLimit) && $this->getCurrentCrawlCount() >= $currentCrawlLimit
-        );
+        $currentCrawlLimit = $this->getCurrentCrawlLimit();
+        if (!is_null($currentCrawlLimit) && $this->getCurrentCrawlCount() >= $currentCrawlLimit) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -487,7 +487,7 @@ class Crawler
     {
         while (
             $this->reachedCrawlLimits() === false &&
-            $crawlUrl = $this->crawlQueue->getFirstPendingUrl()
+            $crawlUrl = $this->crawlQueue->getPendingUrl()
         ) {
             if (
                 $this->crawlProfile->shouldCrawl($crawlUrl->url) === false ||

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -402,7 +402,6 @@ class Crawler
 
         $this->startCrawlingQueue();
 
-        // Notify observers
         foreach ($this->crawlObservers as $crawlObserver) {
             $crawlObserver->finishedCrawling();
         }
@@ -467,7 +466,6 @@ class Crawler
             $this->maximumCrawlCountReached() === false &&
             $crawlUrl = $this->crawlQueue->getFirstPendingUrl()
         ) {
-            // Skip any undesired or already processed URLs.
             if (
                 $this->crawlProfile->shouldCrawl($crawlUrl->url) === false ||
                 $this->crawlQueue->hasAlreadyBeenProcessed($crawlUrl)
@@ -475,12 +473,10 @@ class Crawler
                 continue;
             }
 
-            // Notify the observers "will crawl"
             foreach ($this->crawlObservers as $crawlObserver) {
                 $crawlObserver->willCrawl($crawlUrl->url);
             }
 
-            // Increase the count of processed sites and make as done.
             $this->crawledUrlCount++;
             $this->crawlQueue->markAsProcessed($crawlUrl);
 

--- a/src/LinkAdder.php
+++ b/src/LinkAdder.php
@@ -40,10 +40,6 @@ class LinkAdder
                 return strpos($url->getPath(), '/tel:') === false;
             })
             ->each(function (UriInterface $url) use ($foundOnUrl) {
-                if ($this->crawler->maximumCrawlCountReached()) {
-                    return;
-                }
-
                 $crawlUrl = CrawlUrl::create($url, $foundOnUrl);
 
                 $this->crawler->addToCrawlQueue($crawlUrl);

--- a/tests/ArrayCrawlQueueTest.php
+++ b/tests/ArrayCrawlQueueTest.php
@@ -23,7 +23,7 @@ class ArrayCrawlQueueTest extends TestCase
         $crawlUrl = $this->createCrawlUrl('https://example.com');
         $this->crawlQueue->add($crawlUrl);
 
-        $this->assertEquals($crawlUrl, $this->crawlQueue->getFirstPendingUrl());
+        $this->assertEquals($crawlUrl, $this->crawlQueue->getPendingUrl());
     }
 
     /** @test */
@@ -97,7 +97,7 @@ class ArrayCrawlQueueTest extends TestCase
 
         $pendingUrlCount = 0;
 
-        while ($url = $this->crawlQueue->getFirstPendingUrl()) {
+        while ($url = $this->crawlQueue->getPendingUrl()) {
             $pendingUrlCount++;
             $this->crawlQueue->markAsProcessed($url);
         }

--- a/tests/CrawlerRobotsTest.php
+++ b/tests/CrawlerRobotsTest.php
@@ -168,11 +168,11 @@ class CrawlerRobotsTest extends TestCase
     {
         $crawler = Crawler::create()
             ->setMaximumDepth(10)
-            ->setMaximumCrawlCount(10)
+            ->setTotalCrawlLimit(10)
             ->setUserAgent('test/1.2.3');
 
         $this->assertEquals(10, $crawler->getMaximumDepth());
-        $this->assertEquals(10, $crawler->getMaximumCrawlCount());
+        $this->assertEquals(10, $crawler->getTotalCrawlLimit());
         $this->assertEquals('test/1.2.3', $crawler->getUserAgent());
     }
 

--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -213,7 +213,7 @@ class CrawlerTest extends TestCase
     }
 
     /** @test */
-    public function it_respects_the_maximum_amount_of_urls_to_be_crawled()
+    public function it_respects_the_total_crawl_limit()
     {
         foreach (range(1, 8) as $maximumCrawlCount) {
             $this->resetLog();
@@ -226,6 +226,41 @@ class CrawlerTest extends TestCase
                 ->startCrawling('http://localhost:8080');
 
             $this->assertCrawledUrlCount($maximumCrawlCount);
+        }
+    }
+
+    /** @test */
+    public function it_respects_the_current_crawl_limit()
+    {
+        foreach (range(1, 8) as $maximumCrawlCount) {
+            $this->resetLog();
+
+            Crawler::create()
+                ->setCurrentCrawlLimit($maximumCrawlCount)
+                ->setCrawlObserver(new CrawlLogger())
+                ->ignoreRobots()
+                ->setCrawlProfile(new CrawlInternalUrls('localhost:8080'))
+                ->startCrawling('http://localhost:8080');
+
+            $this->assertCrawledUrlCount($maximumCrawlCount);
+        }
+    }
+
+    /** @test */
+    public function it_respects_current_before_total_limit()
+    {
+        foreach (range(1, 8) as $maximumCrawlCount) {
+            $this->resetLog();
+
+            Crawler::create()
+                ->setCurrentCrawlLimit(4)
+                ->setTotalCrawlLimit($maximumCrawlCount)
+                ->setCrawlObserver(new CrawlLogger())
+                ->ignoreRobots()
+                ->setCrawlProfile(new CrawlInternalUrls('localhost:8080'))
+                ->startCrawling('http://localhost:8080');
+
+            $this->assertCrawledUrlCount($maximumCrawlCount > 4 ? 4 : $maximumCrawlCount);
         }
     }
 

--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -219,7 +219,7 @@ class CrawlerTest extends TestCase
             $this->resetLog();
 
             Crawler::create()
-                ->setMaximumCrawlCount($maximumCrawlCount)
+                ->setTotalCrawlLimit($maximumCrawlCount)
                 ->setCrawlObserver(new CrawlLogger())
                 ->ignoreRobots()
                 ->setCrawlProfile(new CrawlInternalUrls('localhost:8080'))


### PR DESCRIPTION
Hello @freekmurze,

as described in #325, I've noticed some limitations when crawling larger sites in chunks. I've decided to look into what it takes to solve this. This is the outcome. 

It introduces one major change: 

 - The crawl count limit will be checked while the requests are generated and processed, instead of when adding new URLs. This avoids the queue "running out". Meaning, the call queue being continued to fill with the discovered pages just no new requests will be generated after the max crawl count is reached. This allows to reuse the crawl queue directly.

Would be awesome if you could review this and let me know if you foresee any issues or want changes. Thank you in advance!

Cheers,
Peter