### PR TITLE
Fix support for PHP 8.0 in v4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [7.4, 7.3]
+                php: [8.0, 7.4, 7.3]
                 dependency-version: [prefer-lowest, prefer-stable]
 
         name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
@@ -38,4 +38,7 @@ jobs:
                     coverage: none
 
             -   name: Install dependencies
-                run: composer update --no-interaction --prefer-source
+                run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-source
+
+            -   name: Execute tests
+                run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "guzzlehttp/guzzle": "^6.3 || ^7.0",
+        "guzzlehttp/guzzle": "^7.2",
         "guzzlehttp/psr7": "^1.4",
         "nicmart/tree": "^0.3.0",
         "spatie/browsershot": "^3.14",
         "spatie/robots-txt": "^1.0.1",
-        "symfony/dom-crawler": "^4.0 || ^5.0",
+        "symfony/dom-crawler": "^5.2",
         "tightenco/collect": "^5.6 || ^6.0 || ^7.0"
     },
     "require-dev": {

--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -63,8 +63,8 @@ class CrawlerTest extends TestCase
             ->addCrawlObserver(new CrawlLogger('Observer B'))
             ->startCrawling('http://localhost:8080');
 
-        $this->assertContains('Observer A', $this->getLogContents());
-        $this->assertContains('Observer B', $this->getLogContents());
+        $this->assertStringContainsString('Observer A', $this->getLogContents());
+        $this->assertStringContainsString('Observer B', $this->getLogContents());
     }
 
     /** @test */
@@ -77,8 +77,8 @@ class CrawlerTest extends TestCase
             ])
             ->startCrawling('http://localhost:8080');
 
-        $this->assertContains('Observer A', $this->getLogContents());
-        $this->assertContains('Observer B', $this->getLogContents());
+        $this->assertStringContainsString('Observer A', $this->getLogContents());
+        $this->assertStringContainsString('Observer B', $this->getLogContents());
     }
 
     /** @test */


### PR DESCRIPTION
In order to fix https://github.com/spatie/http-status-check/issues/77 i ran into several issues in this package which i fixed in this PR for v4.

I still have to fix v5 and v6 since they lack the following in order to actually test the code with prefer-lowest dependencies:
- composer: update minimum guzzle and dom-crawler version in order to support php 8
- run-tests: Add missing dependency-version to the composer step

I'll try to create PR's for them tomorrow. 

Plz let me know if i fixed this correctly or i should have done something differently ;)