### PR TITLE
Bugfix: infinite loops when a CrawlProfile prevents crawling

### DIFF
--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -493,6 +493,8 @@ class Crawler
                 $this->crawlProfile->shouldCrawl($crawlUrl->url) === false ||
                 $this->crawlQueue->hasAlreadyBeenProcessed($crawlUrl)
             ) {
+                $this->crawlQueue->markAsProcessed($crawlUrl);
+
                 continue;
             }
 


### PR DESCRIPTION
This PR removes a URL from the crawl queue, if a CrawlProfile has prevented it from being crawled.

Without this, a CrawlProfile that returns `false` from its `shouldCrawl()` would cause an infinite loop as the surrounding `while()` will keep re-trying the URL.

The change was caused by a bigger refactor for better queue handling, I believe this was removed in error: https://github.com/spatie/crawler/commit/f2c724a0e9343889a99f40c0225738e547442190#diff-6fcfdccabb1dca200f2a052d8ba2e302f84b1c3c5490b02369c93180b729cfefL461-L470