### PR TITLE
Added laravel application as exemple of using laravel model as queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ Here
 - [ArrayCrawlQueue](https://github.com/spatie/crawler/blob/master/src/CrawlQueues/ArrayCrawlQueue.php)
 - [RedisCrawlQueue (third-party package)](https://github.com/repat/spatie-crawler-redis)
 - [CacheCrawlQueue for Laravel (third-party package)](https://github.com/spekulatius/spatie-crawler-toolkit-for-laravel)
+- [Laravel Model as Queue (third-party example app)](https://github.com/insign/spatie-crawler-queue-with-laravel-model)
 
 ## Changelog
 


### PR DESCRIPTION
The main reason is the others queues packages store all items in one single array, which can be a RAM problem for big sites. Furthermore, you can preserve and use crawled links as you want.