### PR TITLE
change response type hint

### DIFF
--- a/src/ResponseWithCachedBody.php
+++ b/src/ResponseWithCachedBody.php
@@ -3,12 +3,13 @@
 namespace Spatie\Crawler;
 
 use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\ResponseInterface;
 
 class ResponseWithCachedBody extends Response
 {
     protected ?string $cachedBody = null;
 
-    public static function fromGuzzlePsr7Response(Response $response): static
+    public static function fromGuzzlePsr7Response(ResponseInterface $response): static
     {
         return new static(
             $response->getStatusCode(),


### PR DESCRIPTION
I was looking for a way to upgrade [spatie/laravel-export](https://github.com/spatie/laravel-export) to the v5.0 (at least) of `spatie/crawler` and looks like the only gate is this type hint. As you can [see here](https://github.com/spatie/laravel-export/blob/master/src/Crawler/LocalClient.php#L28) `spatie/laravel-export` make use of `nyholm/psr7` and responses comes as `Nyholm\Psr7\Response` instead of `GuzzleHttp\Psr7\Response`. Using `ResponseInterface` as type hint (which make some sense for me) I have both packages working.

EDIT: we may have to find a better name for this function as well, it doesn't make much sense considering that [the calls also work with `ResponseInterface`](https://github.com/spatie/crawler/blob/master/src/Handlers/CrawlRequestFulfilled.php#L28).