### PR TITLE
Keep only guzzlehttp/psr7 v2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.0",
         "guzzlehttp/guzzle": "^7.3",
-        "guzzlehttp/psr7": "^1.8|^2.0",
+        "guzzlehttp/psr7": "^2.0",
         "illuminate/collections": "^8.38",
         "nicmart/tree": "^0.3.0",
         "spatie/browsershot": "^3.45",


### PR DESCRIPTION
Relates to https://github.com/spatie/crawler/issues/379

Bump `guzzlehttp/psr7` to `v2.0` after the change in https://github.com/spatie/crawler/pull/391