### PR TITLE
Fix Puppeteer installation instructions link

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Crawler::create()
 
 In order to make it possible to get the body html after the javascript has been executed, this package depends on
 our [Browsershot](https://github.com/spatie/browsershot) package.
-This package uses [Puppeteer](https://github.com/puppeteer/puppeteer) under the hood. Here are some pointers on [how to install it on your system](https://github.com/spatie/browsershot#requirements).
+This package uses [Puppeteer](https://github.com/puppeteer/puppeteer) under the hood. Here are some pointers on [how to install it on your system](https://spatie.be/docs/browsershot/v2/requirements).
 
 Browsershot will make an educated guess as to where its dependencies are installed on your system.
 By default, the Crawler will instantiate a new Browsershot instance. You may find the need to set a custom created instance using the `setBrowsershot(Browsershot $browsershot)` method.


### PR DESCRIPTION
The `requirements` anchor in `https://github.com/spatie/browsershot` doesn't lead to anywhere, since the section was removed in https://github.com/spatie/browsershot/commit/e3b250cb9fbe7a9bee618ac16c5aad0c239cecb4. This change fixes this issue.