### PR TITLE
Make setParseableMimeTypes prevent URLs from being crawled

### DIFF
--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -28,6 +28,9 @@ class CrawlRequestFulfilled
     public function __invoke(ResponseInterface $response, $index)
     {
         $body = $this->getBody($response);
+        if (empty($body)) {
+            return;
+        }
 
         $robots = new CrawlerRobots(
             $response->getHeaders(),


### PR DESCRIPTION
### Some context
I started using this package yesterday and got the same problem that was also reported on issue https://github.com/spatie/crawler/issues/352

This is probably not the best way to fix the issue, but I don't have enough knowledge and time to do it properly right now.
So if this pull request is not good enough, point me in the right direction or feel free to continue this work, so that we can have a mergeable pull request sooner.

I didn't add new tests because I wasn't able to have the test server running.

### Description
What I did was to check if the response of `getBody` was an empty string and do an early return if it is.
The main purpose was to avoid the execution of [line#41](https://github.com/arturzealves/crawler/blob/main/src/Handlers/CrawlRequestFulfilled.php#L41) and [line#50](https://github.com/arturzealves/crawler/blob/main/src/Handlers/CrawlRequestFulfilled.php#L50).

I was a bit afraid that maybe the `ArrayCrawlQueue` may start to have pending URLs, because [line#38](https://github.com/arturzealves/crawler/blob/main/src/Handlers/CrawlRequestFulfilled.php#L38) is not being executed anymore, but I did some debug while testing manually and with this change, there are no pending URLs in the end.

### How to reproduce
The code I had running on my computer that made me find this issue comes from [this page](https://anlisha.com.np/blog/web-scraping-with-laravel-and-spatie-crawler/). You will have to uncomment the line related with the `setParseableMimeTypes` of course.
On that code example, it will crawl on `https://www.lipsum.com` and with this fix, it won't crawl URLs of `.pdf` or `.gz` files.
 
<img width="780" alt="Screenshot 2022-10-19 at 23 20 30" src="https://user-images.githubusercontent.com/24874009/196815707-dc043fb4-40fb-4cff-80e5-007818d8e2a9.png">

As seen above, in my example, there are no log messages saying `crawled` of URLs that point to files