### PR TITLE
Modify URLs before crawl

### DIFF
--- a/src/CrawlObservers/CrawlObserver.php
+++ b/src/CrawlObservers/CrawlObserver.php
@@ -15,7 +15,7 @@ abstract class CrawlObserver
      *
      * @return \Psr\Http\Message\UriInterface
      */
-    public function filterCrawlUrl(UriInterface $url): UriInterface
+    public function modifyCrawlUrl(UriInterface $url): UriInterface
     {
         return $url;
     }

--- a/src/CrawlObservers/CrawlObserver.php
+++ b/src/CrawlObservers/CrawlObserver.php
@@ -9,6 +9,18 @@ use Psr\Http\Message\UriInterface;
 abstract class CrawlObserver
 {
     /**
+     * Called when CrawlUrl is created to allow for modification
+     *
+     * @param   \Psr\Http\Message\UriInterface  $url
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function filterCrawlUrl(UriInterface $url): UriInterface
+    {
+        return $url;
+    }
+
+    /**
      * Called when the crawler will crawl the url.
      *
      * @param \Psr\Http\Message\UriInterface $url

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -409,9 +409,9 @@ class Crawler
 
         $this->totalUrlCount = $this->crawlQueue->getProcessedUrlCount();
 
-        $this->baseUrl = $baseUrl;
+        $crawlUrl = $this->createCrawlUrl($baseUrl);
 
-        $crawlUrl = CrawlUrl::create($this->baseUrl);
+        $this->baseUrl = $crawlUrl->url;
 
         $this->robotsTxt = $this->createRobotsTxt($crawlUrl->url);
 
@@ -538,5 +538,16 @@ class Crawler
         }
 
         return false;
+    }
+
+    public function createCrawlUrl(UriInterface $url, ?UriInterface $foundOnUrl = null, $id = null): CrawlUrl
+    {
+         $crawlUrl = CrawlUrl::create($url, $foundOnUrl, $id);
+
+         foreach ($this->crawlObservers as $crawlObserver) {
+             $crawlUrl->url = $crawlObserver->filterCrawlUrl($crawlUrl->url);
+         }
+
+         return $crawlUrl;
     }
 }

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -545,7 +545,7 @@ class Crawler
          $crawlUrl = CrawlUrl::create($url, $foundOnUrl, $id);
 
          foreach ($this->crawlObservers as $crawlObserver) {
-             $crawlUrl->url = $crawlObserver->filterCrawlUrl($crawlUrl->url);
+             $crawlUrl->url = $crawlObserver->modifyCrawlUrl($crawlUrl->url);
          }
 
          return $crawlUrl;

--- a/src/LinkAdder.php
+++ b/src/LinkAdder.php
@@ -35,7 +35,7 @@ class LinkAdder
             })
             ->filter(fn (UriInterface $url) => ! str_contains($url->getPath(), '/tel:'))
             ->each(function (UriInterface $url) use ($foundOnUrl) {
-                $crawlUrl = CrawlUrl::create($url, $foundOnUrl);
+                $crawlUrl = $this->crawler->createCrawlUrl($url, $foundOnUrl);
 
                 $this->crawler->addToCrawlQueue($crawlUrl);
             });

--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -16,10 +16,6 @@ use Spatie\Crawler\Test\TestClasses\ModifyCrawlUrl;
 use Spatie\Crawler\Test\TestClasses\Log;
 use stdClass;
 
-use function createCrawler;
-use function expect;
-use function it;
-
 beforeEach(function () {
     skipIfTestServerIsNotRunning();
 

--- a/tests/TestClasses/ModifyCrawlUrl.php
+++ b/tests/TestClasses/ModifyCrawlUrl.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Spatie\Crawler\Test\TestClasses;
+
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
+use Spatie\Crawler\CrawlObservers\CrawlObserver;
+
+class ModifyCrawlUrl extends CrawlObserver
+{
+    public function filterCrawlUrl(UriInterface $url): UriInterface
+    {
+        return Uri::withQueryValues($url, ['dummy' => '123']);
+    }
+
+    public function crawled(UriInterface $url, ResponseInterface $response, ?UriInterface $foundOnUrl = null): void
+    {
+    }
+
+    public function crawlFailed(
+        UriInterface $url,
+        RequestException $requestException,
+        ?UriInterface $foundOnUrl = null
+    ): void {
+    }
+}

--- a/tests/TestClasses/ModifyCrawlUrl.php
+++ b/tests/TestClasses/ModifyCrawlUrl.php
@@ -10,7 +10,7 @@ use Spatie\Crawler\CrawlObservers\CrawlObserver;
 
 class ModifyCrawlUrl extends CrawlObserver
 {
-    public function filterCrawlUrl(UriInterface $url): UriInterface
+    public function modifyCrawlUrl(UriInterface $url): UriInterface
     {
         return Uri::withQueryValues($url, ['dummy' => '123']);
     }


### PR DESCRIPTION
**Overview**

As requested in issue #259, I also needed to modify the URLs to be crawled, but the solution suggested didn't work. The URL passed to `willCrawl` of an observer is an instance of `Psr\Http\Message\UriInterface`, which is immutable. Further, this method doesn't return any values, so there's no easy way to modify the URL. Even if you could modify the URL here, it doesn't work because you're now changing the id of the URL in the queue, so the crawler can no longer recognize if the URL was already crawled. The same URL then gets crawled over and over until the crawl limit is reached. We'd need to modify the URL before it is added to the crawl queue.

**Use Case**

I use the crawler in a plugin I develop to optimize websites, which modifies the HTML of the site on the run. Sometimes, I need the original HTML before modification by the plugin. I can achieve this by passing a query to the URL, such as 'nooptimize=1', which notifies the plugin that it shouldn't modify the HTML on this request. So I need to pass this query to each URL to be crawled so I can access the 'unoptimized' HTML while the plugin is optimizing the HTML for other requests.

**Solution**

I implemented this by adding a new method, `filterCrawlUrl`, to the abstract `CrawlObserver` that custom child observers can overwrite to make modifications if required. Otherwise, it simply passes the same URL back to the crawler. A new method, `Crawler::createCrawlUrl`, is assigned the responsibility to create the `CrawlUrl` and passes the created instance to each observer to filter. All instances of `CrawlUrl::create` are replaced by `Crawler::createCrawlUrl`. This way, the URL gets modified before it is added to the crawl queue.

**Caveat**

Since the links extracted from the HTML are added to the depth tree before they can be modified, you can't set a maximum depth when using the crawler in this way. Setting a maximum depth to any value effectively sets it to 1. You'd have to use some other means to limit the number of links crawled, such as `setCurrentCrawlLimit`, or `setTotalCrawlLimit`.

**Conclusion**

With this implementation, the crawler can now allow URLs to be modified before crawled. This also doesn't affect existing codes, as custom observers do not need to implement the `filterCrawlUrl` if not required. I've added a unit test which shows links being modified as expected and with existing tests passing without any modifications. 

I know it may seem a bit much as the crawler is very popular, and this doesn't seem like a much-requested feature, but it was essential for my use case, so I'm hoping it can be implemented. I'm currently using a modified fork of a previous version because I need to support PHP 7.4. Still, hopefully, in time, I can switch back to the main repo to benefit from added features and improvements. 



