### PR TITLE
Check if rel attribute contains nofollow

### DIFF
--- a/src/LinkAdder.php
+++ b/src/LinkAdder.php
@@ -50,7 +50,7 @@ class LinkAdder
                     return true;
                 }
 
-                if ($this->crawler->mustRejectNofollowLinks() && $link->getNode()->getAttribute('rel') === 'nofollow') {
+                if ($this->crawler->mustRejectNofollowLinks() && str_contains($link->getNode()->getAttribute('rel'), 'nofollow')) {
                     return true;
                 }
 


### PR DESCRIPTION
This PR checks if 'nofollow' is present in the rel attribute.

Multiple values are allowed inside for example:

```<a href="#" ref="nofollow noopener noreferrer">```