### PR TITLE
Define only needed methods in observer implementation

### DIFF
--- a/src/CrawlObservers/CrawlObserver.php
+++ b/src/CrawlObservers/CrawlObserver.php
@@ -18,22 +18,26 @@ abstract class CrawlObserver
     /*
      * Called when the crawler has crawled the given url successfully.
      */
-    abstract public function crawled(
+    public function crawled(
         UriInterface $url,
         ResponseInterface $response,
         UriInterface $foundOnUrl = null,
         string $linkText = null,
-    ): void;
+    ): void
+    {
+    }
 
     /*
      * Called when the crawler had a problem crawling the given url.
      */
-    abstract public function crawlFailed(
+    public function crawlFailed(
         UriInterface $url,
         RequestException $requestException,
         UriInterface $foundOnUrl = null,
         string $linkText = null,
-    ): void;
+    ): void
+    {
+    }
 
     /*
      * Called when the crawl has ended.


### PR DESCRIPTION
Hey there,

In some use cases the observer methods like `crawled` and `crawlFailed` are not always needed in the implementation.
This change allow the developer to only use the necessary methods without having to define other abstract methods.