### PR TITLE
Fix for crawler stopping issue

### DIFF
--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -50,12 +50,6 @@ class CrawlRequestFulfilled
             $this->handleCrawled($responseWithCachedBody, $crawlUrl);
         }
 
-        if (! $this->crawler->getCrawlProfile() instanceof CrawlSubdomains) {
-            if ($crawlUrl->url->getHost() !== $this->crawler->getBaseUrl()->getHost()) {
-                return;
-            }
-        }
-
         if (! $robots->mayFollow()) {
             return;
         }


### PR DESCRIPTION
When the `CrawlSubdomains` profile is not used, no additional code is used to match some hostnames in my opinion. Is there a specific reason to include this code?

Fixes issue #450 