### PR TITLE
Fix return type

### DIFF
--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -67,7 +67,7 @@ class CrawlRequestFulfilled
         usleep($this->crawler->getDelayBetweenRequests());
     }
 
-    protected function getBaseUrl(ResponseInterface $response, CrawlUrl $crawlUrl): Uri
+    protected function getBaseUrl(ResponseInterface $response, CrawlUrl $crawlUrl): UriInterface
     {
         $redirectHistory = $response->getHeader(RedirectMiddleware::HISTORY_HEADER);
 


### PR DESCRIPTION
`Spatie\Crawler\Crawler::startCrawling()` accepts any instance of `Psr\Http\Message\UriInterface`. 
When e.g. an instance of `Spatie\Url\Url` has been provided, everything goes well until `Spatie\Crawler\Handlers\CrawlRequestFulfilled::getBaseUrl()` fails to return an instance of `GuzzleHttp\Psr7\Uri` instead of the PSR interface.  The code doesn't depend on the concrete Guzzle `Uri` however.