### PR TITLE
Add Laravel/Illuminate 11 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,13 +10,14 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 php: [8.3, 8.2, 8.1]
+                illuminate: [10.*, 11.*]
                 dependency-version: [prefer-lowest, prefer-stable]
 
         name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
 
             -   name: Install Puppeteer
                 run: npm install puppeteer
@@ -38,7 +39,9 @@ jobs:
                     coverage: none
 
             -   name: Install dependencies
-                run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-source
+                run: |
+                    composer require "laravel/framework:${{ matrix.illuminate }}" --no-interaction --no-update
+                    composer update --${{ matrix.dependency-version }} --no-interaction --prefer-source
 
             -   name: Execute tests
                 run: vendor/bin/pest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
                 illuminate: [10.*, 11.*]
                 dependency-version: [prefer-lowest, prefer-stable]
 
-        name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
+        name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }} - I ${{ matrix.illuminate }}
 
         steps:
             -   name: Checkout code

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,6 +12,9 @@ jobs:
                 php: [8.3, 8.2, 8.1]
                 illuminate: [10.*, 11.*]
                 dependency-version: [prefer-lowest, prefer-stable]
+                exclude:
+                    - php: 8.1
+                      illuminate: 11.*
 
         name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }} - I ${{ matrix.illuminate }}
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "guzzlehttp/guzzle": "^7.3",
         "guzzlehttp/psr7": "^2.0",
         "illuminate/collections": "^10.0|^11.0",
-        "nicmart/tree": "^0.3.0",
+        "nicmart/tree": "^0.8.0",
         "spatie/browsershot": "^3.45|^4.0",
         "spatie/robots-txt": "^2.0",
         "symfony/dom-crawler": "^6.0|^7.0"

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
         "php": "^8.1",
         "guzzlehttp/guzzle": "^7.3",
         "guzzlehttp/psr7": "^2.0",
-        "illuminate/collections": "^10.0",
+        "illuminate/collections": "^10.0|^11.0",
         "nicmart/tree": "^0.3.0",
         "spatie/browsershot": "^3.45|^4.0",
         "spatie/robots-txt": "^2.0",
-        "symfony/dom-crawler": "^6.0 | ^7.0"
+        "symfony/dom-crawler": "^6.0|^7.0"
     },
     "require-dev": {
         "pestphp/pest": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,6 @@
             "Spatie\\Crawler\\Test\\": "tests"
         }
     },
-    "scripts": {
-        "test": "phpunit"
-    }
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
This forces to install Illuminate 10 or 11 depending on the selected Laravel version.