### PR TITLE
Check original URL against depth tree when visited link is a redirect

### DIFF
--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -447,7 +447,7 @@ class Crawler
         }
     }
 
-    public function addToDepthTree(UriInterface $url, UriInterface $parentUrl, ?Node $node = null): ?Node
+    public function addToDepthTree(UriInterface $url, UriInterface $parentUrl, ?UriInterface $originalUrl = null, ?Node $node = null): ?Node
     {
         if (is_null($this->maximumDepth)) {
             return new Node((string) $url);
@@ -457,7 +457,7 @@ class Crawler
 
         $returnNode = null;
 
-        if ($node->getValue() === (string) $parentUrl) {
+        if ($node->getValue() === (string) $parentUrl || $node->getValue() === (string) $originalUrl) {
             $newNode = new Node((string) $url);
 
             $node->addChild($newNode);
@@ -466,7 +466,7 @@ class Crawler
         }
 
         foreach ($node->getChildren() as $currentNode) {
-            $returnNode = $this->addToDepthTree($url, $parentUrl, $currentNode);
+            $returnNode = $this->addToDepthTree($url, $parentUrl, $originalUrl, $currentNode);
 
             if (! is_null($returnNode)) {
                 break;

--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -62,8 +62,9 @@ class CrawlRequestFulfilled
         }
 
         $baseUrl = $this->getBaseUrl($response, $crawlUrl);
+        $originalUrl = $crawlUrl->url;
 
-        $this->urlParser->addFromHtml($body, $baseUrl);
+        $this->urlParser->addFromHtml($body, $baseUrl, $originalUrl);
 
         usleep($this->crawler->getDelayBetweenRequests());
     }

--- a/src/UrlParsers/LinkUrlParser.php
+++ b/src/UrlParsers/LinkUrlParser.php
@@ -21,7 +21,7 @@ class LinkUrlParser implements UrlParser
         $this->crawler = $crawler;
     }
 
-    public function addFromHtml(string $html, UriInterface $foundOnUrl): void
+    public function addFromHtml(string $html, UriInterface $foundOnUrl, ?UriInterface $originalUrl = null): void
     {
         $allLinks = $this->extractLinksFromHtml($html, $foundOnUrl);
 
@@ -29,7 +29,7 @@ class LinkUrlParser implements UrlParser
             ->filter(fn (Url $url) => $this->hasCrawlableScheme($url))
             ->map(fn (Url $url) => $this->normalizeUrl($url))
             ->filter(function (Url $url) use ($foundOnUrl) {
-                if (! $node = $this->crawler->addToDepthTree($url, $foundOnUrl)) {
+                if (! $node = $this->crawler->addToDepthTree($url, $foundOnUrl, $originalUrl)) {
                     return false;
                 }
 

--- a/src/UrlParsers/SitemapUrlParser.php
+++ b/src/UrlParsers/SitemapUrlParser.php
@@ -20,7 +20,7 @@ class SitemapUrlParser implements UrlParser
         $this->crawler = $crawler;
     }
 
-    public function addFromHtml(string $html, UriInterface $foundOnUrl): void
+    public function addFromHtml(string $html, UriInterface $foundOnUrl, ?UriInterface $originalUrl = null): void
     {
         $allLinks = $this->extractLinksFromHtml($html, $foundOnUrl);
 
@@ -28,7 +28,7 @@ class SitemapUrlParser implements UrlParser
             ->filter(fn (Url $url) => $this->hasCrawlableScheme($url))
             ->map(fn (Url $url) => $this->normalizeUrl($url))
             ->filter(function (Url $url) use ($foundOnUrl) {
-                if (! $node = $this->crawler->addToDepthTree($url, $foundOnUrl)) {
+                if (! $node = $this->crawler->addToDepthTree($url, $foundOnUrl, $originalUrl)) {
                     return false;
                 }
 

--- a/src/UrlParsers/UrlParser.php
+++ b/src/UrlParsers/UrlParser.php
@@ -9,5 +9,5 @@ interface UrlParser
 {
     public function __construct(Crawler $crawler);
 
-    public function addFromHtml(string $html, UriInterface $foundOnUrl): void;
+    public function addFromHtml(string $html, UriInterface $foundOnUrl, ?UriInterface $originalUrl = null): void;
 }


### PR DESCRIPTION
Fixes #466.

Could, in theory, pass only the original link to `addToDepthTree` instead, if a technically breaking change is undesirable.