### PR TITLE
Catch unhandled Browsershot exceptions in `crawlFailed`

### DIFF
--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -51,6 +51,7 @@ class CrawlRequestFulfilled
 
                 $this->crawler->getCrawlObservers()->crawlFailed($crawlUrl, $exception);
 
+                usleep($this->crawler->getDelayBetweenRequests());
                 return;
             }
 

--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -51,7 +51,6 @@ class CrawlRequestFulfilled
 
                 $this->crawler->getCrawlObservers()->crawlFailed($crawlUrl, $exception);
 
-                usleep($this->crawler->getDelayBetweenRequests());
                 return;
             }
 
@@ -65,13 +64,13 @@ class CrawlRequestFulfilled
             $this->handleCrawled($responseWithCachedBody, $crawlUrl);
         }
 
-        if (!$this->crawler->getCrawlProfile() instanceof CrawlSubdomains) {
+        if (! $this->crawler->getCrawlProfile() instanceof CrawlSubdomains) {
             if ($crawlUrl->url->getHost() !== $this->crawler->getBaseUrl()->getHost()) {
                 return;
             }
         }
 
-        if (!$robots->mayFollow()) {
+        if (! $robots->mayFollow()) {
             return;
         }
 
@@ -103,7 +102,7 @@ class CrawlRequestFulfilled
     {
         $contentType = $response->getHeaderLine('Content-Type');
 
-        if (!$this->isMimetypeAllowedToParse($contentType)) {
+        if (! $this->isMimetypeAllowedToParse($contentType)) {
             return '';
         }
 
@@ -127,7 +126,7 @@ class CrawlRequestFulfilled
                 $newDataRead = null;
             }
 
-            if (!$newDataRead) {
+            if (! $newDataRead) {
                 break;
             }
 
@@ -152,7 +151,7 @@ class CrawlRequestFulfilled
             return true;
         }
 
-        if (!count($this->crawler->getParseableMimeTypes())) {
+        if (! count($this->crawler->getParseableMimeTypes())) {
             return true;
         }
 

--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -51,6 +51,7 @@ class CrawlRequestFulfilled
 
                 $this->crawler->getCrawlObservers()->crawlFailed($crawlUrl, $exception);
 
+                usleep($this->crawler->getDelayBetweenRequests());
                 return;
             }
 
@@ -64,13 +65,13 @@ class CrawlRequestFulfilled
             $this->handleCrawled($responseWithCachedBody, $crawlUrl);
         }
 
-        if (! $this->crawler->getCrawlProfile() instanceof CrawlSubdomains) {
+        if (!$this->crawler->getCrawlProfile() instanceof CrawlSubdomains) {
             if ($crawlUrl->url->getHost() !== $this->crawler->getBaseUrl()->getHost()) {
                 return;
             }
         }
 
-        if (! $robots->mayFollow()) {
+        if (!$robots->mayFollow()) {
             return;
         }
 
@@ -102,7 +103,7 @@ class CrawlRequestFulfilled
     {
         $contentType = $response->getHeaderLine('Content-Type');
 
-        if (! $this->isMimetypeAllowedToParse($contentType)) {
+        if (!$this->isMimetypeAllowedToParse($contentType)) {
             return '';
         }
 
@@ -126,7 +127,7 @@ class CrawlRequestFulfilled
                 $newDataRead = null;
             }
 
-            if (! $newDataRead) {
+            if (!$newDataRead) {
                 break;
             }
 
@@ -151,7 +152,7 @@ class CrawlRequestFulfilled
             return true;
         }
 
-        if (! count($this->crawler->getParseableMimeTypes())) {
+        if (!count($this->crawler->getParseableMimeTypes())) {
             return true;
         }
 

--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -134,7 +134,7 @@ it('fails gracefully when browsershot fails', function () {
     })->not->toThrow(ProcessFailedException::class);
 
     expect(['url' => 'http://localhost:8080/simulate-activity'])->toBeCrawledOnce();
-})->only();
+});
 
 it('uses a crawl profile to determine what should be crawled', function () {
     $crawlProfile = new class() extends CrawlProfile

--- a/tests/server/server.js
+++ b/tests/server/server.js
@@ -211,6 +211,38 @@ app.get('/sitemap2.xml', function (req, res) {
     res.end(sitemap2);
 });
 
+// Route that initiates but never completes the response
+app.get('/never-complete', (req, res) => {
+  req.socket.setTimeout(0); // Disable automatic socket timeout
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.write('Starting but never completing...\n');
+  // Intentionally do not call res.end() or send more data, leaving the response hanging
+});
+
+app.get('/simulate-activity', (req, res) => {
+  res.send(`
+    <!DOCTYPE html>
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Simulated Network Activity</title>
+      </head>
+      <body>
+        <h1>This page simulates a never-ending network request</h1>
+        <script>
+          function keepBusy() {
+            fetch('/never-complete')
+          }
+
+          keepBusy();
+          setInterval(keepBusy, 1000); 
+        </script>
+      </body>
+    </html>
+  `);
+});
+
 
 let server = app.listen(8080, function () {
     const host = 'localhost';


### PR DESCRIPTION
Fixes #324.

I ran into this issue myself, and it ended up crashing the crawler prematurely. This PR catches any `ProcessFailedException`s on the Browsershot method, and sends it to observers via `crawlFailed`. I also included a test that loads a URL that never goes to network idle, triggering the 30s network timeout from Puppeteer. Originally, this creates an exception, but now it is caught appropriately.

One note here is that exceptions like Puppeteer not finding a Chrome binary are no longer displayed to the user by default, they would need to see the exception in `crawlFailed`. I'm not sure if there is a way to "fix" that, but that in theory should be what happens, anyway. 

Feel free to ask to use a different method of testing this; this test takes 30s to execute which may be undesirable (maybe use Browsershot's `waitForFunction` to get the 5s timeout, like what @kmcluckie posted)?