### PR TITLE
Fix setParsableMimeTypes()

### DIFF
--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -29,6 +29,10 @@ class CrawlRequestFulfilled
     public function __invoke(ResponseInterface $response, $index)
     {
         $body = $this->getBody($response);
+        if (empty($body)) {
+            usleep($this->crawler->getDelayBetweenRequests());
+            return;
+        }
 
         $robots = new CrawlerRobots(
             $response->getHeaders(),

--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -417,8 +417,8 @@ it('will only crawl correct mime types when asked to', function () {
         ->startCrawling('http://localhost:8080/content-types');
 
     $urls = [
-        ['url' => 'http://localhost:8080/content-types/music.html', 'foundOn' => 'http://localhost:8080/content-types/music.mp3'],
-        ['url' => 'http://localhost:8080/content-types/video.html', 'foundOn' => 'http://localhost:8080/content-types/video.mkv'],
+        ['url' => 'http://localhost:8080/content-types/music.mp3', 'foundOn' => 'http://localhost:8080/content-types'],
+        ['url' => 'http://localhost:8080/content-types/video.mkv', 'foundOn' => 'http://localhost:8080/content-types'],
         ['url' => 'http://localhost:8080/content-types/normal.html', 'foundOn' => 'http://localhost:8080/content-types'],
     ];
 
@@ -434,7 +434,34 @@ it('will only crawl correct mime types when asked to', function () {
         },
     );
 
-    assertCrawledUrlCount(4);
+    assertCrawledUrlCount(2);
+})->only();
+
+it('will only crawl correct mime types when asked to when executing javascript', function () {
+    createCrawler()
+        ->executeJavaScript()
+        ->setParseableMimeTypes(['text/html', 'text/plain'])
+        ->startCrawling('http://localhost:8080/content-types');
+
+    $urls = [
+        ['url' => 'http://localhost:8080/content-types/music.mp3', 'foundOn' => 'http://localhost:8080/content-types'],
+        ['url' => 'http://localhost:8080/content-types/video.mkv', 'foundOn' => 'http://localhost:8080/content-types'],
+        ['url' => 'http://localhost:8080/content-types/normal.html', 'foundOn' => 'http://localhost:8080/content-types'],
+    ];
+
+    expect($urls)->sequence(
+        function ($url) {
+            $url->notToBeCrawled();
+        },
+        function ($url) {
+            $url->notToBeCrawled();
+        },
+        function ($url) {
+            $url->toBeCrawledOnce();
+        },
+    );
+
+    assertCrawledUrlCount(2);
 });
 
 it('will crawl all content types when not explicitly whitelisted', function () {

--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -435,7 +435,7 @@ it('will only crawl correct mime types when asked to', function () {
     );
 
     assertCrawledUrlCount(2);
-})->only();
+});
 
 it('will only crawl correct mime types when asked to when executing javascript', function () {
     createCrawler()


### PR DESCRIPTION
Addresses issues #352 and #369, and PR #432.

The `setParsableMimeTypes` option does not actually prevent a *crawl* of a URL, it only prevents URLs that originate from that page from being crawled.

If `executeJavascript` is enabled in tandem, the `setParsableMimeTypes` option becomes completely broken; as it turns out, the method with which mime types are ignored conflicts with Browsershot's JavaScript execution, since it overwrites the `$body` variable:

```php
if ($this->crawler->mayExecuteJavaScript()) {
    $body = $this->getBodyAfterExecutingJavaScript($crawlUrl->url);
    $response = $response->withBody(Utils::streamFor($body));
}
```

This PR prevents pages with non-parsable mime types from being crawled completely, edits the test for mime types to be more representative of what this feature should accomplish, and adds an additional test to validate that the issue is fixed when executing JS, as well.