### PR TITLE
set spatie/browsershot minimal version to 5.0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "guzzlehttp/psr7": "^2.0",
         "illuminate/collections": "^10.0|^11.0|^12.0",
         "nicmart/tree": "^0.9",
-        "spatie/browsershot": "^3.45|^4.0|^5.0",
+        "spatie/browsershot": "^5.0.5",
         "spatie/robots-txt": "^2.0",
         "symfony/dom-crawler": "^6.0|^7.0"
     },


### PR DESCRIPTION
Because of a security vulnerability in the older versions: https://nvd.nist.gov/vuln/detail/CVE-2025-1022