### PR TITLE
Close response body streams after processing

### DIFF
--- a/src/Handlers/CrawlRequestFulfilled.php
+++ b/src/Handlers/CrawlRequestFulfilled.php
@@ -25,6 +25,7 @@ class CrawlRequestFulfilled
         try {
             $this->handle($response, $index);
         } finally {
+            $response->getBody()->close();
             $this->crawler->applyDelay();
         }
     }

--- a/tests/Handlers/CrawlRequestFulfilledTest.php
+++ b/tests/Handlers/CrawlRequestFulfilledTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Spatie\Crawler\Crawler;
+use Spatie\Crawler\CrawlObservers\CrawlObserver;
+use Spatie\Crawler\CrawlProgress;
+use Spatie\Crawler\CrawlResponse;
+
+it('closes response body streams after processing', function () {
+    $responses = [];
+
+    $observer = new class($responses) extends CrawlObserver
+    {
+        public function __construct(protected array &$responses) {}
+
+        public function crawled(
+            string $url,
+            CrawlResponse $response,
+            CrawlProgress $progress,
+        ): void {
+            $this->responses[] = $response->toPsrResponse();
+        }
+    };
+
+    Crawler::create('https://example.com')
+        ->addObserver($observer)
+        ->fake([
+            'https://example.com' => '<a href="/page1">Page 1</a><a href="/page2">Page 2</a>',
+            'https://example.com/page1' => 'Page 1 content',
+            'https://example.com/page2' => 'Page 2 content',
+        ])
+        ->start();
+
+    expect($responses)->toHaveCount(3);
+
+    foreach ($responses as $response) {
+        expect($response->getBody()->isReadable())->toBeFalse();
+    }
+});


### PR DESCRIPTION
## Summary

- Explicitly close response body streams in `CrawlRequestFulfilled` after processing each URL
- When using `StreamHandler` with stream mode, unclosed response bodies keep file descriptors open. Over a large crawl (1000+ URLs), this exhausts the OS file descriptor limit and causes subsequent requests to fail with connection errors
- The `finally` block ensures streams are closed even if an exception occurs during processing
- Observers can still read the body via `CrawlResponse::body()` which uses the cached string that was read before the stream is closed