### PR TITLE
Add a shouldStopCallback hook for graceful external stops

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,23 @@ Crawler::create('https://example.com')
     ->foundUrls();
 ```
 
+If you need to stop a crawl based on external state, you can register a callback that receives the current crawler instance and is checked before scheduling each next request:
+
+```php
+use Spatie\Crawler\Crawler;
+
+$shouldStop = false;
+
+Crawler::create('https://example.com')
+    ->shouldStopCallback(function (Crawler $crawler) use (&$shouldStop) {
+        return $shouldStop;
+    })
+    ->onCrawled(function (string $url) use (&$shouldStop) {
+        $shouldStop = true;
+    })
+    ->start();
+```
+
 ## Support us
 
 [<img src="https://github-ads.s3.eu-central-1.amazonaws.com/crawler.jpg?t=1" width="419px" />](https://spatie.be/github-ad-click/crawler)

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -255,7 +255,7 @@ class Crawler
      * Register a callback that is evaluated before scheduling each next request.
      * Returning true interrupts the crawl and makes start() return FinishReason::Interrupted.
      *
-     * @param callable(self):bool $shouldStopCallback
+     * @param  callable(self):bool  $shouldStopCallback
      */
     public function shouldStopCallback(callable $shouldStopCallback): self
     {

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -75,6 +75,8 @@ class Crawler
 
     protected bool $shouldStop = false;
 
+    protected ?\Closure $shouldStopCallback = null;
+
     protected int $crawledUrlCount = 0;
 
     protected int $failedUrlCount = 0;
@@ -245,6 +247,21 @@ class Crawler
     public function fake(array $fakes): self
     {
         $this->fakes = $fakes;
+
+        return $this;
+    }
+
+    /**
+     * Register a callback that is evaluated before scheduling each next request.
+     * Returning true interrupts the crawl and makes start() return FinishReason::Interrupted.
+     *
+     * @param callable(self):bool $shouldStopCallback
+     */
+    public function shouldStopCallback(callable $shouldStopCallback): self
+    {
+        $this->shouldStopCallback = $shouldStopCallback instanceof \Closure
+            ? $shouldStopCallback
+            : \Closure::fromCallable($shouldStopCallback);
 
         return $this;
     }
@@ -513,6 +530,12 @@ class Crawler
             $this->reachedTimeLimits() === false &&
             $crawlUrl = $this->crawlQueue->getPendingUrl()
         ) {
+            if ($this->shouldStopCallback !== null && ($this->shouldStopCallback)($this)) {
+                $this->shouldStop = true;
+
+                break;
+            }
+
             if ($this->crawlQueue->hasAlreadyBeenProcessed($crawlUrl)) {
                 $this->crawlQueue->markAsProcessed($crawlUrl);
 

--- a/tests/Crawler/GracefulShutdownTest.php
+++ b/tests/Crawler/GracefulShutdownTest.php
@@ -32,6 +32,47 @@ it('stops crawling when shouldStop is set', function () {
     expect($reason)->toBe(FinishReason::Interrupted);
 });
 
+it('stops crawling when shouldStopCallback returns true immediately', function () {
+    $crawled = [];
+
+    $reason = Crawler::create('https://example.com')
+        ->fake(fullSiteFakes())
+        ->depth(3)
+        ->concurrency(1)
+        ->shouldStopCallback(fn (Crawler $crawler) => true)
+        ->onCrawled(function (string $url) use (&$crawled) {
+            $crawled[] = $url;
+        })
+        ->start();
+
+    expect($crawled)->toBeEmpty();
+    expect($reason)->toBe(FinishReason::Interrupted);
+});
+
+it('stops crawling when shouldStopCallback becomes true between requests', function () {
+    $crawled = [];
+    $shouldStop = false;
+
+    $reason = Crawler::create('https://example.com')
+        ->fake(fullSiteFakes())
+        ->depth(3)
+        ->concurrency(1)
+        ->shouldStopCallback(function (Crawler $crawler) use (&$shouldStop) {
+            return $shouldStop;
+        })
+        ->onCrawled(function (string $url) use (&$crawled, &$shouldStop) {
+            $crawled[] = $url;
+
+            if (count($crawled) === 1) {
+                $shouldStop = true;
+            }
+        })
+        ->start();
+
+    expect(count($crawled))->toBe(1);
+    expect($reason)->toBe(FinishReason::Interrupted);
+});
+
 it('calls finishedCrawling after graceful shutdown', function () {
     $finishedCalled = false;
 


### PR DESCRIPTION
 ## Add a shouldStopCallback hook for graceful external stops
 
- Some applications need to stop an active crawl based on external state, such as a database flag, an admin action, or a feature toggle.
- Today, the only graceful stop mechanism is the internal `shouldStop` flag, which makes these integrations awkward and pushes tests toward mutating internal state.
- This adds a fluent `shouldStopCallback()` hook that is evaluated before scheduling each next request. When it returns `true`, the crawl stops gracefully and `start()` returns `FinishReason::Interrupted`.