### PR TITLE
Skip fnmatch for URLs longer than FILENAME_MAX

### DIFF
--- a/src/Concerns/HasCrawlScope.php
+++ b/src/Concerns/HasCrawlScope.php
@@ -16,7 +16,7 @@ trait HasCrawlScope
      * value so behavior is consistent across platforms; real URLs almost never
      * exceed this anyway.
      */
-    private const FNMATCH_MAX_LENGTH = 1024;
+    protected int $fnmatchMaxLength = 1024;
 
     protected ?CrawlProfile $crawlProfile = null;
 
@@ -89,7 +89,7 @@ trait HasCrawlScope
 
     public function matchesAlwaysCrawl(string $url): bool
     {
-        if (strlen($url) > self::FNMATCH_MAX_LENGTH) {
+        if (strlen($url) > $this->fnmatchMaxLength) {
             return false;
         }
 
@@ -104,7 +104,7 @@ trait HasCrawlScope
 
     public function matchesNeverCrawl(string $url): bool
     {
-        if (strlen($url) > self::FNMATCH_MAX_LENGTH) {
+        if (strlen($url) > $this->fnmatchMaxLength) {
             return false;
         }
 

--- a/src/Concerns/HasCrawlScope.php
+++ b/src/Concerns/HasCrawlScope.php
@@ -10,6 +10,14 @@ use Spatie\Crawler\CrawlProfiles\CrawlProfile;
 
 trait HasCrawlScope
 {
+    /**
+     * fnmatch() rejects strings longer than the platform's FILENAME_MAX with a
+     * warning (4096 on Linux, 1024 on macOS/BSD). We use the lowest common
+     * value so behavior is consistent across platforms; real URLs almost never
+     * exceed this anyway.
+     */
+    private const FNMATCH_MAX_LENGTH = 1024;
+
     protected ?CrawlProfile $crawlProfile = null;
 
     protected ?string $scopeMode = null;
@@ -81,6 +89,10 @@ trait HasCrawlScope
 
     public function matchesAlwaysCrawl(string $url): bool
     {
+        if (strlen($url) > self::FNMATCH_MAX_LENGTH) {
+            return false;
+        }
+
         foreach ($this->alwaysCrawlPatterns as $pattern) {
             if (fnmatch($pattern, $url)) {
                 return true;
@@ -92,6 +104,10 @@ trait HasCrawlScope
 
     public function matchesNeverCrawl(string $url): bool
     {
+        if (strlen($url) > self::FNMATCH_MAX_LENGTH) {
+            return false;
+        }
+
         foreach ($this->neverCrawlPatterns as $pattern) {
             if (fnmatch($pattern, $url)) {
                 return true;

--- a/tests/Crawler/AlwaysNeverCrawlTest.php
+++ b/tests/Crawler/AlwaysNeverCrawlTest.php
@@ -105,3 +105,21 @@ it('alwaysCrawl bypasses crawl profile', function () {
 
     expect($crawled)->toContain('https://external.com/page');
 });
+
+it('does not crash when matching alwaysCrawl against a url longer than fnmatch can handle', function () {
+    $longUrl = 'https://example.com/'.str_repeat('a', 4200);
+
+    $crawler = Crawler::create('https://example.com')
+        ->alwaysCrawl(['https://example.com/*']);
+
+    expect($crawler->matchesAlwaysCrawl($longUrl))->toBeFalse();
+});
+
+it('does not crash when matching neverCrawl against a url longer than fnmatch can handle', function () {
+    $longUrl = 'https://example.com/'.str_repeat('a', 4200);
+
+    $crawler = Crawler::create('https://example.com')
+        ->neverCrawl(['https://example.com/*']);
+
+    expect($crawler->matchesNeverCrawl($longUrl))->toBeFalse();
+});


### PR DESCRIPTION
`fnmatch()` raises a warning when the haystack exceeds the platform's `FILENAME_MAX` (4096 on Linux, 1024 on macOS/BSD). Under a framework like Laravel that converts warnings to `ErrorException` this kills the crawl job with `fnmatch(): Filename exceeds the maximum allowed length of 4096 characters` whenever a discovered URL is unusually long and `alwaysCrawl()` or `neverCrawl()` patterns are set.

Guard `matchesAlwaysCrawl()` / `matchesNeverCrawl()` with a length check (1024, the lowest common `FILENAME_MAX` across supported platforms) so overly-long URLs short-circuit to `false` and fall through to the normal `CrawlProfile::shouldCrawl()` check downstream. Real URLs almost never exceed this, and a URL too long to glob can't meaningfully match a pattern anyway.

Two regression tests added in `AlwaysNeverCrawlTest.php` cover both methods.