### PR TITLE
Add failing test for delay blocking concurrency

### DIFF
--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -3,6 +3,7 @@
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
 use Spatie\Crawler\Crawler;
 use Spatie\Crawler\CrawlResponse;
 use Spatie\Crawler\Test\TestServer\TestServer;
@@ -10,7 +11,6 @@ use Spatie\Crawler\Throttlers\AdaptiveThrottle;
 use Spatie\Crawler\Throttlers\FixedDelayThrottle;
 use Spatie\Crawler\Throttlers\Throttle;
 use Spatie\Crawler\TransferStatistics;
-use Psr\Http\Message\RequestInterface;
 
 beforeAll(function () {
     TestServer::start();

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use GuzzleHttp\Middleware;
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Psr7\Response;
 use Spatie\Crawler\Crawler;
 use Spatie\Crawler\CrawlResponse;
 use Spatie\Crawler\Test\TestServer\TestServer;
@@ -8,6 +10,7 @@ use Spatie\Crawler\Throttlers\AdaptiveThrottle;
 use Spatie\Crawler\Throttlers\FixedDelayThrottle;
 use Spatie\Crawler\Throttlers\Throttle;
 use Spatie\Crawler\TransferStatistics;
+use Psr\Http\Message\RequestInterface;
 
 beforeAll(function () {
     TestServer::start();
@@ -143,6 +146,89 @@ it('throttle is called on real failed requests', function () {
 
     // sleep() should be called for both the parent page (fulfilled) and the 404 (failed).
     expect($sleepCount)->toBeGreaterThanOrEqual(2);
+});
+
+it('does not let delay block concurrent in-flight requests', function () {
+    $measureCrawl = function (int $delayInMilliseconds): array {
+        $count = 0;
+        $start = microtime(true);
+
+        Crawler::create('https://example.com/', [
+            'handler' => new class
+            {
+                /** @var array<int, array{Promise, string}> */
+                private array $pending = [];
+
+                public function __invoke(RequestInterface $request): Promise
+                {
+                    $promise = new Promise(function () {
+                        $this->resolvePendingRequests();
+                    });
+
+                    $this->pending[] = [$promise, (string) $request->getUri()];
+
+                    return $promise;
+                }
+
+                private function resolvePendingRequests(): void
+                {
+                    if ($this->pending === []) {
+                        return;
+                    }
+
+                    usleep(300_000);
+
+                    $pending = $this->pending;
+                    $this->pending = [];
+
+                    foreach ($pending as [$promise, $url]) {
+                        $promise->resolve(new Response(
+                            200,
+                            ['Content-Type' => 'text/html'],
+                            $this->htmlFor($url),
+                        ));
+                    }
+                }
+
+                private function htmlFor(string $url): string
+                {
+                    if (parse_url($url, PHP_URL_PATH) !== '/') {
+                        return '<html><body>leaf</body></html>';
+                    }
+
+                    $body = '<html><body>';
+
+                    for ($i = 1; $i <= 20; $i++) {
+                        $body .= "<a href=\"/p{$i}\">p{$i}</a>";
+                    }
+
+                    return $body.'</body></html>';
+                }
+            },
+        ])
+            ->ignoreRobots()
+            ->concurrency(20)
+            ->delay($delayInMilliseconds)
+            ->onCrawled(function () use (&$count) {
+                $count++;
+            })
+            ->start();
+
+        return [
+            'count' => $count,
+            'elapsed' => microtime(true) - $start,
+        ];
+    };
+
+    $withoutDelay = $measureCrawl(0);
+    $withDelay = $measureCrawl(100);
+
+    expect($withoutDelay['count'])->toBe(21);
+    expect($withDelay['count'])->toBe(21);
+
+    // The handler resolves each concurrent batch after 300ms.
+    // A 100ms crawl delay should not add roughly 21 * 100ms to the total runtime.
+    expect($withDelay['elapsed'])->toBeLessThan($withoutDelay['elapsed'] + 0.75);
 });
 
 it('respects robots.txt over real http', function () {


### PR DESCRIPTION
This draft PR does not attempt to fix the crawler yet. It only adds a failing test that demonstrates a concurrency bug around `delay()`.

## Problem

`concurrency()` and `delay()` are configured as separate crawl settings:

```php
Crawler::create($url)
    ->concurrency(20)
    ->delay(100)
    ->start();
```

The expected behavior is that concurrency controls how many requests may be in flight, while delay controls how request starts are paced. A configured delay should not block already in-flight requests from completing or prevent other completed responses from being handled.

Currently, the delay is applied from the fulfilled/failed request callbacks. Those callbacks run while Guzzle's pool is being driven by `Pool::promise()->wait()`. Because the delay is implemented as `usleep()`, it blocks the single PHP thread that is also responsible for advancing the pool. As a result, a delay on one completed request stalls the whole pool and effectively serializes response handling/request scheduling.

## Proof in this PR

The new test uses an in-process custom Guzzle handler. The handler returns promises and resolves each pending batch after 300ms, simulating a slow network batch that can complete concurrently without requiring sockets, subprocesses, or `pcntl`.

The crawl is set up as:

- one root page
- 20 linked leaf pages
- `concurrency(20)`
- first run with `delay(0)`
- second run with `delay(100)`

If delay and concurrency compose correctly, the second run should remain close to the first run: the 20 leaf requests can all be in flight together, and the 100ms delay should not add roughly 21 * 100ms of wall-clock time.

On the current implementation, the test fails because the delayed crawl takes much longer. Locally, the failure looks like:

```text
Failed asserting that 2.8s is less than 1.4s
```

That demonstrates the current behavior: `delay(100)` is applied as serial blocking time across the crawl instead of being hidden behind concurrent in-flight requests.

## Notes

This is intentionally left as a failing regression test so the issue and expected behavior are clear before choosing an implementation strategy. The fix likely needs to move delay/throttle pacing out of the response callbacks and into request scheduling, without blocking Guzzle's pool/event loop.
