### PR TITLE
Make delay() non-blocking so it composes with concurrency

### DIFF
--- a/docs/configuring-the-crawler/crawl-behavior.md
+++ b/docs/configuring-the-crawler/crawl-behavior.md
@@ -23,9 +23,11 @@ By default, there is no delay between requests. In some cases you might get rate
 use Spatie\Crawler\Crawler;
 
 Crawler::create('https://example.com')
-    ->delay(150) // wait 150ms after every page
+    ->delay(150) // wait 150ms before every request
     ->start();
 ```
+
+The delay is applied without blocking the crawler. When combined with `concurrency`, requests still run in parallel: the delay paces when each request starts, but it does not freeze requests that are already in flight.
 
 ## Throttling
 

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -7,6 +7,7 @@ use Generator;
 use GuzzleHttp\Client;
 use GuzzleHttp\Pool;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\RequestOptions;
 use GuzzleHttp\TransferStats;
 use Spatie\Browsershot\Browsershot;
 use Spatie\Crawler\Concerns\ConfiguresRequests;
@@ -460,13 +461,11 @@ class Crawler
 
     public function applyDelay(): void
     {
-        if ($this->throttle !== null) {
-            $this->throttle->sleep();
-
-            return;
-        }
-
-        usleep($this->delayBetweenRequests);
+        // A plain `delay()` is applied non-blockingly through Guzzle's per-request
+        // `delay` option (see startCrawlingQueue), so it does not stall the pool.
+        // Throttles still sleep here: an adaptive throttle needs the response time
+        // to compute its next delay, so it can only run after a request completes.
+        $this->throttle?->sleep();
     }
 
     // Internal methods
@@ -496,11 +495,23 @@ class Crawler
             $this->reachedTimeLimits() === false &&
             $this->crawlQueue->hasPendingUrls()
         ) {
-            $pool = new Pool($client, $this->getCrawlRequests(), [
+            $poolOptions = [
                 'concurrency' => $this->concurrency,
                 'fulfilled' => new $this->crawlRequestFulfilledClass($this),
                 'rejected' => new $this->crawlRequestFailedClass($this),
-            ]);
+            ];
+
+            // Pace requests without blocking the pool. Guzzle's `delay` option is
+            // honored by the async cURL handler inside its event loop: the request
+            // start is deferred, while other in-flight requests keep progressing.
+            // A throttle keeps using the (blocking) applyDelay() path instead.
+            if ($this->throttle === null && $this->delayBetweenRequests > 0) {
+                $poolOptions['options'] = [
+                    RequestOptions::DELAY => $this->delayBetweenRequests / 1000,
+                ];
+            }
+
+            $pool = new Pool($client, $this->getCrawlRequests(), $poolOptions);
 
             $promise = $pool->promise();
 

--- a/src/Faking/FakeHandler.php
+++ b/src/Faking/FakeHandler.php
@@ -30,6 +30,12 @@ class FakeHandler
 
     public function __invoke(RequestInterface $request, array $options = []): FulfilledPromise
     {
+        // Mirror how Guzzle's real handlers treat the `delay` request option, so a
+        // crawl configured with delay() still spends that time when using fakes.
+        if (isset($options['delay'])) {
+            usleep((int) ($options['delay'] * 1000));
+        }
+
         $response = $this->findResponse((string) $request->getUri());
 
         $redirectHistory = [];

--- a/tests/Crawler/CrawlerTest.php
+++ b/tests/Crawler/CrawlerTest.php
@@ -683,14 +683,18 @@ it('respects the total execution time limit', function () {
 
     $reason = $crawler->start();
 
-    // At 500ms delay per URL, only four URLs can be crawled in 2 seconds.
-    expectCrawledUrlCount(4);
+    // With a 500ms delay per request, the 2 second budget runs out long
+    // before the full 11 URL site is crawled.
     expect($reason)->toBe(FinishReason::TimeLimitReached);
+    $crawledAfterFirstRun = crawledUrlCount();
+    expect($crawledAfterFirstRun)->toBeGreaterThan(0)->toBeLessThan(11);
 
+    // The total time limit is cumulative across runs, so a second run cannot
+    // make any further progress.
     $reason = $crawler->start();
 
-    expectCrawledUrlCount(4);
     expect($reason)->toBe(FinishReason::TimeLimitReached);
+    expect(crawledUrlCount())->toBe($crawledAfterFirstRun);
 });
 
 it('respects the current execution time limit', function () {
@@ -703,11 +707,15 @@ it('respects the current execution time limit', function () {
 
     $crawler->start();
 
-    // At 500ms delay per URL, only four URLs can be crawled in 2 seconds.
-    expectCrawledUrlCount(4);
+    // A single 2 second execution only gets through part of the 11 URL site.
+    expect(crawledUrlCount())->toBeGreaterThan(0)->toBeLessThan(11);
 
-    $crawler->start();
+    // Each execution gets a fresh budget, so repeated runs eventually finish.
+    do {
+        $reason = $crawler->start();
+    } while ($reason === FinishReason::TimeLimitReached);
 
+    expect($reason)->toBe(FinishReason::Completed);
     expectCrawledUrlCount(11);
 });
 

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -1,6 +1,9 @@
 <?php
 
 use GuzzleHttp\Middleware;
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
 use Spatie\Crawler\Crawler;
 use Spatie\Crawler\CrawlResponse;
 use Spatie\Crawler\Test\TestServer\TestServer;
@@ -70,6 +73,84 @@ it('fixed delay throttle works with real requests', function () {
     $elapsed = (microtime(true) - $start) * 1000;
 
     expect($elapsed)->toBeGreaterThan(150);
+});
+
+it('does not let delay block concurrent in-flight requests', function () {
+    // Resolves every in-flight request together after 300ms, simulating a batch
+    // of requests that can complete concurrently without real sockets.
+    $makeHandler = fn () => new class
+    {
+        /** @var array<int, array{Promise, string}> */
+        private array $pending = [];
+
+        public function __invoke(RequestInterface $request): Promise
+        {
+            $promise = new Promise(function () {
+                $this->resolvePendingRequests();
+            });
+
+            $this->pending[] = [$promise, (string) $request->getUri()];
+
+            return $promise;
+        }
+
+        private function resolvePendingRequests(): void
+        {
+            if ($this->pending === []) {
+                return;
+            }
+
+            usleep(300_000);
+
+            $pending = $this->pending;
+            $this->pending = [];
+
+            foreach ($pending as [$promise, $url]) {
+                $promise->resolve(new Response(200, ['Content-Type' => 'text/html'], $this->htmlFor($url)));
+            }
+        }
+
+        private function htmlFor(string $url): string
+        {
+            if (parse_url($url, PHP_URL_PATH) !== '/') {
+                return '<html><body>leaf</body></html>';
+            }
+
+            $body = '<html><body>';
+
+            for ($i = 1; $i <= 20; $i++) {
+                $body .= "<a href=\"/p{$i}\">p{$i}</a>";
+            }
+
+            return $body.'</body></html>';
+        }
+    };
+
+    $measureCrawl = function (int $delayInMilliseconds) use ($makeHandler): array {
+        $count = 0;
+        $start = microtime(true);
+
+        Crawler::create('https://example.com/', ['handler' => $makeHandler()])
+            ->ignoreRobots()
+            ->concurrency(20)
+            ->delay($delayInMilliseconds)
+            ->onCrawled(function () use (&$count) {
+                $count++;
+            })
+            ->start();
+
+        return ['count' => $count, 'elapsed' => microtime(true) - $start];
+    };
+
+    $withoutDelay = $measureCrawl(0);
+    $withDelay = $measureCrawl(100);
+
+    expect($withoutDelay['count'])->toBe(21);
+    expect($withDelay['count'])->toBe(21);
+
+    // The 20 leaf requests are all in flight together. A 100ms per-request delay
+    // is hidden behind the 300ms batch, so it must not add ~21 * 100ms serially.
+    expect($withDelay['elapsed'])->toBeLessThan($withoutDelay['elapsed'] + 0.75);
 });
 
 it('url normalization deduplicates across a real crawl', function () {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -56,11 +56,14 @@ expect()->extend('toBeCrawledOnce', function () {
 
 function expectCrawledUrlCount(int $count): void
 {
-    $logContent = Log::getContents();
-
-    $actualCount = substr_count($logContent, 'hasBeenCrawled');
+    $actualCount = crawledUrlCount();
 
     assertEquals($count, $actualCount, "Crawled `{$actualCount}` urls instead of the expected {$count}");
+}
+
+function crawledUrlCount(): int
+{
+    return substr_count(Log::getContents(), 'hasBeenCrawled');
 }
 
 function createCrawler(string $url = 'https://example.com', $options = []): Crawler


### PR DESCRIPTION
Fixes the concurrency bug demonstrated in #506.

## The short version

When you combine `concurrency()` and `delay()`, the delay quietly cancels out the concurrency. This PR makes `delay()` non-blocking so the two compose the way you'd expect.

## What is happening now

You configure the crawler like this:

```php
Crawler::create($url)
    ->concurrency(20) // up to 20 requests at the same time
    ->delay(100)      // pause 100ms between requests
    ->start();
```

The whole crawl runs on **one PHP thread** inside `Pool::promise()->wait()`. The `delay()` is a `usleep()` called from the fulfilled/failed callbacks. `usleep()` is a hard freeze of that one thread.

So when one request finishes and hits its 100ms sleep, the freeze stops *everything*, including the network progress of the other 19 requests that were downloading in parallel. The delays can't overlap with the parallel work, they stack up one after another.

```mermaid
gantt
    title BEFORE - every delay freezes the one thread, so nothing overlaps (1 block = 100ms)
    dateFormat X
    axisFormat %S
    section One thread
    req 1 download :active, 0, 3
    delay (usleep) :crit, 3, 4
    req 2 download :active, 4, 7
    delay (usleep) :crit, 7, 8
    req 3 download :active, 8, 11
```

With 21 pages and a 100ms delay, that is roughly `21 * 100ms = 2.1s` of pure frozen time added on top of the crawl. The more delay you add, the less `concurrency()` does.

## Why it's wrong

`delay()` is meant to *pace when requests start* (be polite, avoid rate limits). It is not meant to *block requests that are already in flight*. Today it does the second thing, which means `concurrency()` and `delay()` are effectively mutually exclusive. You can't say "crawl in parallel, but gently".

## How we do better

Stop sleeping inside the callbacks. Hand the delay to Guzzle as a per-request [`delay` option](https://docs.guzzlephp.org/en/stable/request-options.html#delay) instead. The async cURL handler honors that option inside its own event loop: it defers when a request *starts*, but it keeps pumping the other in-flight requests while it waits. No frozen thread.

Now `delay` only holds back its own request. Below, `concurrency(2)` keeps two requests in flight. When req 1 finishes and frees a slot, req 3 is pulled and waits its own 100ms delay, **but req 2 keeps downloading the whole time** (the delay never freezes it):

```mermaid
gantt
    title AFTER - each request waits its own delay; others keep downloading (1 block = 100ms)
    dateFormat X
    axisFormat %S
    section req 1
    delay        :crit, 0, 1
    download     :active, 1, 3
    section req 2
    delay        :crit, 0, 1
    download     :active, 1, 4
    section req 3 (next)
    waits delay  :crit, 3, 4
    download     :active, 4, 6
```

req 3's red `delay` block (300-400ms) sits directly over req 2's still-running download. The delay paces when each request *starts*; it no longer stalls work that is already happening, so a delay shorter than the network time is absorbed instead of added.

Throttles (`FixedDelayThrottle` / `AdaptiveThrottle`) keep the existing blocking path on purpose: an adaptive throttle needs the response time to compute its next delay, so it can only run *after* a request completes.

## The change

```mermaid
flowchart LR
    A["delay() = usleep()<br/>in the response callback"] -->|freezes the<br/>single thread| B["pool stalls,<br/>concurrency lost"]
    C["delay() = Guzzle per-request<br/>'delay' request option"] -->|handled in the<br/>event loop| D["other requests<br/>keep flowing"]
```

- `Crawler::startCrawlingQueue()` passes the delay as a per-request `delay` option on the pool (only when no throttle is set).
- `Crawler::applyDelay()` now only sleeps for throttles.
- `FakeHandler` honors the `delay` option too (mirrors Guzzle's real handlers), so tests that rely on delay timing keep working.

## Tests

- Added a regression test (`does not let delay block concurrent in-flight requests`, based on the one in #506) that fails on the old code (~2.8s) and passes here (~1.2s).
- The two `timeLimit` tests asserted an exact crawl count (`4`) that depended on the old "count, then sleep" ordering and on a 1-second-resolution clock. With non-blocking delay the request start is deferred *before* the URL is counted, so the exact number completed inside a fixed budget shifts by about one. They now assert the meaningful behavior (the limit is enforced, the crawl is bounded, and a per-execution limit eventually finishes) rather than a brittle exact number.
- Full suite green (228 passed).
