### PR TITLE
Skip signal handler registration when pcntl functions are disabled

### DIFF
--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -563,7 +563,11 @@ class Crawler
 
     protected function registerSignalHandlers(): void
     {
-        if (! extension_loaded('pcntl')) {
+        if (
+            ! extension_loaded('pcntl') ||
+            ! function_exists('pcntl_async_signals') ||
+            ! function_exists('pcntl_signal')
+        ) {
             return;
         }
 

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -563,11 +563,7 @@ class Crawler
 
     protected function registerSignalHandlers(): void
     {
-        if (
-            ! extension_loaded('pcntl') ||
-            ! function_exists('pcntl_async_signals') ||
-            ! function_exists('pcntl_signal')
-        ) {
+        if (! $this->canHandleSignals()) {
             return;
         }
 
@@ -584,11 +580,18 @@ class Crawler
 
     protected function unregisterSignalHandlers(): void
     {
-        if (! extension_loaded('pcntl')) {
+        if (! $this->canHandleSignals()) {
             return;
         }
 
         pcntl_signal(SIGINT, SIG_DFL);
         pcntl_signal(SIGTERM, SIG_DFL);
+    }
+
+    protected function canHandleSignals(): bool
+    {
+        return extension_loaded('pcntl')
+            && function_exists('pcntl_async_signals')
+            && function_exists('pcntl_signal');
     }
 }


### PR DESCRIPTION
This merge request fixes an issue on shared hosting.

The crawler checked if the pcntl extension is loaded, but on some shared servers the extension is loaded while the needed functions are disabled.

Because of that, the crawler tried to call pcntl_async_signals() and failed with an error.