### PR TITLE
Add support for Guzzle 8

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -9,9 +9,13 @@ on:
 
 jobs:
   phpstan:
-    name: phpstan
+    name: phpstan - Guzzle ${{ matrix.guzzle }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        guzzle: ['^7.3', '^8.0']
     steps:
       - uses: actions/checkout@v6
 
@@ -22,7 +26,7 @@ jobs:
           coverage: none
 
       - name: Install composer dependencies
-        uses: ramsey/composer-install@v3
+        run: composer update --with="guzzlehttp/guzzle:${{ matrix.guzzle }}" --no-interaction --prefer-dist
 
       - name: Run PHPStan
         run: ./vendor/bin/phpstan --error-format=github

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,8 +10,9 @@ jobs:
             matrix:
                 php: [8.5, 8.4]
                 dependency-version: [prefer-lowest, prefer-stable]
+                guzzle: ['^7.3', '^8.0']
 
-        name: P${{ matrix.php }} - ${{ matrix.dependency-version }}
+        name: P${{ matrix.php }} - Guzzle ${{ matrix.guzzle }} - ${{ matrix.dependency-version }}
 
         steps:
             -   name: Checkout code
@@ -25,7 +26,7 @@ jobs:
                     coverage: none
 
             -   name: Install dependencies
-                run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-source
+                run: composer update --${{ matrix.dependency-version }} --with="guzzlehttp/guzzle:${{ matrix.guzzle }}" --no-interaction --prefer-source
 
             -   name: Execute tests
                 run: vendor/bin/pest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,7 +26,7 @@ jobs:
                     coverage: none
 
             -   name: Install dependencies
-                run: composer update --${{ matrix.dependency-version }} --with="guzzlehttp/guzzle:${{ matrix.guzzle }}" --no-interaction --prefer-source
+                run: composer update --${{ matrix.dependency-version }} --with="guzzlehttp/guzzle:${{ matrix.guzzle }}" --no-interaction --prefer-dist
 
             -   name: Execute tests
                 run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": "^8.4",
-        "guzzlehttp/guzzle": "^7.3",
-        "guzzlehttp/psr7": "^2.0",
+        "guzzlehttp/guzzle": "^7.3|^8.0",
+        "guzzlehttp/psr7": "^2.0|^3.0",
         "spatie/robots-txt": "^2.0",
         "symfony/css-selector": "^7.0|^8.0",
         "symfony/dom-crawler": "^7.0|^8.0"

--- a/src/CrawlObservers/CollectUrlsObserver.php
+++ b/src/CrawlObservers/CollectUrlsObserver.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\Crawler\CrawlObservers;
 
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TooManyRedirectsException;
 use Spatie\Crawler\CrawledUrl;
 use Spatie\Crawler\CrawlProgress;
 use Spatie\Crawler\CrawlResponse;
@@ -37,7 +39,12 @@ class CollectUrlsObserver extends CrawlObserver
         ?ResourceType $resourceType = null,
         ?TransferStatistics $transferStats = null,
     ): void {
-        $response = $requestException->getResponse();
+        // Guzzle 8 removed getResponse() from RequestException; it only lives on
+        // response-carrying subclasses. These expose it in both Guzzle 7 and 8,
+        // covering every failure that reaches here with a response.
+        $response = $requestException instanceof BadResponseException || $requestException instanceof TooManyRedirectsException
+            ? $requestException->getResponse()
+            : null;
 
         $this->crawledUrls[] = new CrawledUrl(
             url: $url,


### PR DESCRIPTION
Widens the `guzzlehttp/guzzle` and `guzzlehttp/psr7` constraints to allow Guzzle 8 alongside 7. No breaking changes for Guzzle 7 users.

Guzzle 8 removed `getResponse()` from `RequestException`, so `CollectUrlsObserver` now reads the response via `BadResponseException`/`TooManyRedirectsException`, which expose it identically in both Guzzle 7 and 8.

The test suite and PHPStan now run against both Guzzle 7 and 8 in CI.