### PR TITLE
Fix Guzzle 8 exception handling for responses and retries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": "^8.4",
-        "guzzlehttp/guzzle": "^7.3|^8.0",
-        "guzzlehttp/psr7": "^2.0|^3.0",
+        "guzzlehttp/guzzle": "^7.8.2 || ^8.0",
+        "guzzlehttp/psr7": "^2.6.3 || ^3.0",
         "psr/http-client": "^1.0",
         "spatie/robots-txt": "^2.0",
         "symfony/css-selector": "^7.0|^8.0",

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "php": "^8.4",
         "guzzlehttp/guzzle": "^7.3|^8.0",
         "guzzlehttp/psr7": "^2.0|^3.0",
+        "psr/http-client": "^1.0",
         "spatie/robots-txt": "^2.0",
         "symfony/css-selector": "^7.0|^8.0",
         "symfony/dom-crawler": "^7.0|^8.0"

--- a/src/Concerns/ConfiguresRequests.php
+++ b/src/Concerns/ConfiguresRequests.php
@@ -10,6 +10,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\TransferStats;
+use Psr\Http\Client\NetworkExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Spatie\Crawler\Faking\FakeHandler;
@@ -275,7 +276,11 @@ trait ConfiguresRequests
                     return false;
                 }
 
-                if ($exception instanceof ConnectException) {
+                // Guzzle 8 reclassifies read/operation timeouts as
+                // NetworkTimeoutException/NetworkException, which are not
+                // ConnectException subclasses. NetworkExceptionInterface covers
+                // the whole network-failure family in both Guzzle 7 and 8.
+                if ($exception instanceof ConnectException || $exception instanceof NetworkExceptionInterface) {
                     return true;
                 }
 

--- a/src/CrawlObservers/CollectUrlsObserver.php
+++ b/src/CrawlObservers/CollectUrlsObserver.php
@@ -2,9 +2,7 @@
 
 namespace Spatie\Crawler\CrawlObservers;
 
-use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Exception\TooManyRedirectsException;
 use Spatie\Crawler\CrawledUrl;
 use Spatie\Crawler\CrawlProgress;
 use Spatie\Crawler\CrawlResponse;
@@ -39,10 +37,11 @@ class CollectUrlsObserver extends CrawlObserver
         ?ResourceType $resourceType = null,
         ?TransferStatistics $transferStats = null,
     ): void {
-        // Guzzle 8 removed getResponse() from RequestException; it only lives on
-        // response-carrying subclasses. These expose it in both Guzzle 7 and 8,
-        // covering every failure that reaches here with a response.
-        $response = $requestException instanceof BadResponseException || $requestException instanceof TooManyRedirectsException
+        // Guzzle 8 removed getResponse() from the base RequestException; it now
+        // lives only on its response-carrying subclasses. method_exists() keeps
+        // this working across Guzzle 7 (where the base still has it) and 8, and
+        // covers every response-carrying exception, not just a hardcoded subset.
+        $response = method_exists($requestException, 'getResponse')
             ? $requestException->getResponse()
             : null;
 


### PR DESCRIPTION
This follows up on #509, which added Guzzle 8 support but did not properly account for its exception reclassification, introducing a bug. Guzzle 8 moved `getResponse()` off the base `RequestException` onto its response-carrying subclasses, so `CollectUrlsObserver` reading it only from `BadResponseException` and `TooManyRedirectsException` misses the other response-carrying types on Guzzle 8 and drops responses that Guzzle 7 exposed on a plain `RequestException`. It now guards with `method_exists()` and handles every response-carrying exception properly.

Separately, Guzzle 8 reclassified read and operation timeouts from `ConnectException` to `NetworkTimeoutException`/`NetworkException`, which are siblings of `ConnectException` rather than subclasses, so the retry middleware stopped retrying the most common transient failure even though Guzzle 7 retried it. It now also matches `Psr\Http\Client\NetworkExceptionInterface`, which covers the whole network-failure family on both Guzzle 7 and 8.

On the dependency side, the `guzzlehttp/guzzle` and `guzzlehttp/psr7` constraints are raised to `^7.8.2 || ^8.0` and `^2.6.3 || ^3.0`, the first releases that support the PHP 8.4, and `psr/http-client` is now required directly since the retry change relies on its `NetworkExceptionInterface`.
